### PR TITLE
Add initial support for manual approval phase type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vscode/
 docs/_build/
 node_modules/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Handel-CodePipeline is a library that creates AWS CodePipelines with Handel as t
    :maxdepth: 1
    :caption: Supported Pipeline Phase Types
 
+   phase-types/approval
    phase-types/github
    phase-types/codebuild
    phase-types/handel

--- a/docs/phase-types/approval.rst
+++ b/docs/phase-types/approval.rst
@@ -1,0 +1,27 @@
+Approval
+========
+The *Approval* phase type configures a pipeline phase to require manual approval before proceeding with the rest of the pipeline.
+
+Parameters
+----------
+This phase type doesn't take any parameters in the *handel-codepipeline.yml* file.
+
+Secrets
+-------
+This phase type doesn't prompt for any secrets when creating the pipeline.
+
+Example Phase Configuration
+---------------------------
+This snippet of a *handel-codepipeline.yml* file shows the GitHub phase being configured:
+
+.. code-block:: yaml
+    
+    version: 1
+
+    pipelines:
+      dev:
+        ...
+        phases:
+        - type: approval
+          name: ManualApproval
+        ...

--- a/docs/phase-types/codebuild.rst
+++ b/docs/phase-types/codebuild.rst
@@ -28,6 +28,10 @@ Parameters
      - {}
      - A set of key/value pairs that will be injected into the running CodeBuild jobs.
 
+Secrets
+-------
+This phase type doesn't prompt for any secrets when creating the pipeline.
+
 Example Phase Configuration
 ---------------------------
 This snippet of a handel-codepipeline.yml file shows the CodeBuild phase being configured:

--- a/docs/phase-types/handel.rst
+++ b/docs/phase-types/handel.rst
@@ -19,6 +19,10 @@ Parameters
      - 
      - A list of one or more environment names from your Handel file that you wish to deploy in this phase.
 
+Secrets
+-------
+This phase type doesn't prompt for any secrets when creating the pipeline.
+
 Example Phase Configuration
 ---------------------------
 This snippet of a handel-codepipeline.yml file shows the Handel phase being configured:

--- a/lib/phases/approval/index.js
+++ b/lib/phases/approval/index.js
@@ -1,0 +1,32 @@
+const winston = require('winston');
+
+function getApprovalPhaseSpec(phaseContext) {
+    return {
+        name: phaseContext.phaseName,
+        actions: [
+            {
+                inputArtifacts: [],
+                outputArtifacts: [],
+                name: phaseContext.phaseName,
+                actionTypeId: {
+                    category: "Approval",
+                    owner: "AWS",
+                    version: "1",
+                    provider: "Manual"
+                },
+                configuration: {},
+                runOrder: 1
+            }
+        ]
+    }
+}
+
+exports.getSecretsForPhase = function () {
+    return Promise.resolve({});
+}
+
+exports.createPhase = function (phaseContext, accountConfig) {
+    winston.info(`Creating manual approval phase '${phaseContext.phaseName}'`);
+
+    return Promise.resolve(getApprovalPhaseSpec(phaseContext))
+}

--- a/test/phases/approval/approval-test.js
+++ b/test/phases/approval/approval-test.js
@@ -1,0 +1,48 @@
+const expect = require('chai').expect;
+const approval = require('../../../lib/phases/approval');
+const sinon = require('sinon');
+const inquirer = require('inquirer');
+
+describe('approval module', function() {
+    let sandbox;
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('getSecretsForPhase', function() {
+        it('should not prompt for any secrets', function() {
+            let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({}));
+
+            return approval.getSecretsForPhase()
+                .then(results => {
+                    expect(results).to.deep.equal({});
+                    expect(promptStub.notCalled).to.be.true;
+                });
+        });
+    });
+
+    describe('createPhase', function() {
+        let phaseContext = {
+            phaseName: 'MyPhase',
+            params: {},
+            secrets: {}
+        }
+        let accountConfig = {
+            account_id: '111111111111',
+            region: 'us-west-2'
+        }
+
+        it('should return the configuration for the phase', function() {
+            return approval.createPhase(phaseContext, accountConfig)
+                .then(phaseSpec => {
+                    expect(phaseSpec.name).to.equal(phaseContext.phaseName);
+                }); 
+        });
+    });
+
+});


### PR DESCRIPTION
This phase type doesn't yet support notifications for manual
approval actions. That support will come in a later change.

Resolves #6 