### PR TITLE
Add initial support for Handel Delete phase

### DIFF
--- a/docs/getting-started/handel-codepipeline-file.rst
+++ b/docs/getting-started/handel-codepipeline-file.rst
@@ -2,7 +2,7 @@
 
 Handel CodePipeline File
 ========================
-Handel-CodePipeline requires you to specify a pipeline specification file, in addition to your Handel file. This specification file must be named *handel-codepipeline.yml*. It doesn't contain any secrets, so it may be committed to your repository alongside your Handel file.
+Handel-CodePipeline requires you to specify a pipeline specification file, which contains information on how your pipeline should be configured. This specification file must be named *handel-codepipeline.yml*. It doesn't contain any secrets, so it may be committed to your repository alongside your Handel file.
 
 Handel-CodePipeline File Specification
 --------------------------------------
@@ -12,6 +12,8 @@ The Handel-Codepipeline file is a YAML file that has the following schema:
     
     version: 1
 
+    name: <app_name>
+
     pipelines:
       <pipeline_name>:
         phases:
@@ -20,6 +22,8 @@ The Handel-Codepipeline file is a YAML file that has the following schema:
           <phase_params>
 
 The above file schema shows that you can specify one or more pipelines, giving them a unique <pipeline_name>. In each pipeline, you specify an ordered series of phases. Each phase has a <type> and a <name>. The type field is defined by Handel-Codepipeline, and the name field is one that you specify.
+
+In addition, you must specify a top-level *name* field, which is a string you choose for the overall name of your application.
 
 Each phase then has additional parameters that are specific to the phase type. See the [[Pipeline Phase Types]] section for information on each phase type.
 

--- a/docs/getting-started/introduction.rst
+++ b/docs/getting-started/introduction.rst
@@ -6,6 +6,4 @@ How does this library work?
 ---------------------------
 You specify a file called *handel-codepipeline.yml* in your code repository. This file contains a YAML specification of how the library should configure your pipeline.
 
-In addition to this pipeline specification file, you'll also need to specify your `Handel file <https://handel.readthedocs.io>`_ that defines how your application should be deployed. Handel-CodePipeline needs to read this to get information about your environment file.
-
-Once you've defined your specification, you can run the library. It will prompt you for further pieces of information, after which it will create the pipeline.
+Once you've defined your *handel-codepipeline.yml* file, you can run the library. It will prompt you for further pieces of information, after which it will create the pipeline.

--- a/docs/getting-started/using-handel-codepipeline.rst
+++ b/docs/getting-started/using-handel-codepipeline.rst
@@ -12,29 +12,27 @@ Creating New Pipelines
 ----------------------
 To create a new pipeline, do the following:
 
-1. Make sure you have already created your `Handel file <https://handel.readthedocs.io/en/latest/handel-basics/handel-file.html>`_ that specifies how your application should be deployed.
-2. Create a new :ref:`handel-codepipeline-file` in your repository. 
-3. Install Handel-CodePipeline:
+1. Create a new :ref:`handel-codepipeline-file` in your repository. 
+2. Install Handel-CodePipeline:
 
     .. code-block:: none
     
         npm install -g handel-codepipeline
 
-4. Run Handel-CodePipeline:
+3. Run Handel-CodePipeline:
 
     .. code-block:: none
 
         handel-codepipeline
 
-5. Handel-CodePipeline will walk you through a series of questions, asking you to provide further input:
+4. Handel-CodePipeline will walk you through a series of questions, asking you to provide further input:
 
     .. code-block:: none
 
         Welcome to the Handel CodePipeline setup wizard
-        ? Please enter the path to the application's Handel config file ./handel.yml
-        ? Please enter the path to the Handel-CodePipeline config file ./handel-codepipeline.yml
+        ? Please enter the name of the pipeline from your handel-codepipeline.yml file that you would like to create prd
+        ? Please enter the name of the account where your pipeline will be created my-account
         ? Please enter the path to the directory containing the Handel account configuration files /path/to/account/config/files
         ? Please enter a valid GitHub access token (CodePipeline will use this to pull your repo) SOMEFAKETOKEN
-        ? What is the ID of the account you wish to use for your pipeline 'dev' 111111111111
 
 After you provide the appropriate input, Handel-CodePipeline will create the pipeline with the specified phases.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,5 +20,6 @@ Handel-CodePipeline is a tool to easily create AWS CodePipelines, including supp
    phase-types/github
    phase-types/codebuild
    phase-types/handel
+   phase-types/handel_delete
    phase-types/runscope
    phase-types/slack_notify

--- a/docs/phase-types/handel_delete.rst
+++ b/docs/phase-types/handel_delete.rst
@@ -1,0 +1,49 @@
+Handel Delete
+=============
+The *Handel Delete* phase type configures a pipeline phase to delete one or more of your Handel application environments that was previously deployed. This phase is useful if you want to spin up an ephemeral environment, run tests against it, and delete the environment after the tests.
+
+.. WARNING::
+
+    **This environment will DELETE all resources in an environment, including data resources such as RDS, ElastiCache, and DynamoDB!**
+    
+    The data from these will likely be unrecoverable once deleted. You should only use this phase type against ephemeral environments that don't need to persist data.
+
+    **Use this phase at your own risk.** It is highly recommended you double-check which environments are being deleted before adding this phase to a pipeline.
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - environments_to_delete
+     - list<string>
+     - Yes
+     - 
+     - A list of one or more environment names from your Handel file that you wish to delete in this phase.
+
+Secrets
+-------
+This phase type doesn't prompt for any secrets when creating the pipeline.
+
+Example Phase Configuration
+---------------------------
+This snippet of a handel-codepipeline.yml file shows the Handel phase being configured:
+
+.. code-block:: yaml
+
+    version: 1
+
+    pipelines:
+      dev:
+        phases:
+        - type: handel_delete
+          name: Teardown
+          environments_to_delete:
+          - dev
+        ...

--- a/lib/phases/handel_delete/delete-buildspec.yml
+++ b/lib/phases/handel_delete/delete-buildspec.yml
@@ -1,0 +1,9 @@
+version: 0.1
+
+phases:
+  pre_build:
+    commands:
+    - npm install -g handel
+  build:
+    commands:
+    - handel delete -e $ENVS_TO_DELETE -c $HANDEL_ACCOUNT_CONFIG -d

--- a/lib/phases/handel_delete/delete-phase-service-policy.json
+++ b/lib/phases/handel_delete/delete-phase-service-policy.json
@@ -1,0 +1,12 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "*"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}

--- a/lib/phases/handel_delete/index.js
+++ b/lib/phases/handel_delete/index.js
@@ -1,0 +1,103 @@
+const iamCalls = require('../../aws/iam-calls');
+const codeBuildCalls = require('../../aws/codebuild-calls');
+const util = require('../../util/util');
+const winston = require('winston');
+
+function getDeleteProjectName(appName, envsToDelete) {
+    return `${appName}-delete-${envsToDelete.join("-")}`
+}
+
+function createDeletePhaseServiceRole(accountId) {
+    let roleName = 'HandelCodePipelineDeletePhaseServiceRole'
+    return iamCalls.createRoleIfNotExists(roleName, 'codebuild.amazonaws.com')
+        .then(role => {
+            let policyArn = `arn:aws:iam::${accountId}:policy/handel-codepipeline/${roleName}`;
+            let policyDocument = util.loadJsonFile(`${__dirname}/delete-phase-service-policy.json`);
+            return iamCalls.createPolicyIfNotExists(roleName, policyArn, policyDocument);
+        })
+        .then(policy => {
+            return iamCalls.attachPolicyToRole(policy.Arn, roleName);
+        })
+        .then(policyAttachment => {
+            return iamCalls.getRole(roleName);
+        });
+}
+
+function createDeletePhaseCodeBuildProject(phaseContext, accountConfig) {
+    let appName = phaseContext.appName;
+    let deleteProjectName = getDeleteProjectName(appName, phaseContext.params.environments_to_delete)
+    return createDeletePhaseServiceRole(phaseContext.accountConfig.account_id)
+        .then(deletePhaseRole => {
+            let handelDeleteEnvVars = {
+                ENVS_TO_DELETE: phaseContext.params.environments_to_delete.join(","),
+                HANDEL_ACCOUNT_CONFIG: new Buffer(JSON.stringify(accountConfig)).toString("base64")
+            }
+            let handelDeleteImage = "aws/codebuild/nodejs:6.3.1";
+            let handelDeleteBuildSpec = util.loadFile(`${__dirname}/delete-buildspec.yml`);
+
+            return codeBuildCalls.getProject(deleteProjectName)
+                .then(buildProject => {
+                    if (!buildProject) {
+                        winston.info(`Creating Handel delete phase CodeBuild project ${deleteProjectName}`);
+                        return codeBuildCalls.createProject(deleteProjectName, appName, handelDeleteImage, handelDeleteEnvVars, phaseContext.accountConfig.account_id, deletePhaseRole.Arn, phaseContext.accountConfig.region, handelDeleteBuildSpec);
+                    }
+                    else {
+                        winston.info(`Updating Handel delete phase CodeBuild project ${deleteProjectName}`);
+                        return codeBuildCalls.updateProject(deleteProjectName, appName, handelDeleteImage, handelDeleteEnvVars, phaseContext.accountConfig.account_id, deletePhaseRole.Arn, phaseContext.accountConfig.region, handelDeleteBuildSpec)
+                    }
+                });
+        });
+}
+
+function getCodePipelinePhaseSpec(phaseContext) {
+    return {
+        name: phaseContext.phaseName,
+        actions: [
+            {
+                inputArtifacts: [
+                    {
+                        name: `Output_Build`
+                    }
+                ],
+                name: phaseContext.phaseName,
+                actionTypeId: {
+                    category: "Test",
+                    owner: "AWS",
+                    version: "1",
+                    provider: "CodeBuild"
+                },
+                configuration: {
+                    ProjectName: getDeleteProjectName(phaseContext.appName, phaseContext.params.environments_to_delete)
+                },
+                runOrder: 1
+            }
+        ]
+    }
+}
+
+exports.check = function (phaseConfig) {
+    let errors = [];
+
+    if (!phaseConfig.environments_to_delete) {
+        errors.push(`GitHub - The 'environments_to_delete' parameter is required`);
+    }
+
+    return errors;
+}
+
+exports.getSecretsForPhase = function () {
+    return Promise.resolve({});
+}
+
+exports.createPhase = function (phaseContext, accountConfig) {
+    return createDeletePhaseCodeBuildProject(phaseContext, accountConfig)
+        .then(codeBuildProject => {
+            return getCodePipelinePhaseSpec(phaseContext);
+        });
+}
+
+exports.deletePhase = function (phaseContext, accountConfig) {
+    winston.info(`Delete CodeBuild project for '${phaseContext.phaseName}'`);
+    let codeBuildProjectName = getDeleteProjectName(phaseContext.appName, phaseContext.params.environments_to_delete);
+    return codeBuildCalls.deleteProject(codeBuildProjectName);
+}

--- a/test/phases/handel_delete/handel-delete-test.js
+++ b/test/phases/handel_delete/handel-delete-test.js
@@ -1,0 +1,115 @@
+const handelDelete = require('../../../lib/phases/handel_delete');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const iamCalls = require('../../../lib/aws/iam-calls');
+const codebuildCalls = require('../../../lib/aws/codebuild-calls');
+
+describe('handel phase module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('check', function () {
+        it('should require the environments_to_delete parameter', function () {
+            let phaseConfig = {};
+            let errors = handelDelete.check(phaseConfig);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.include(`The 'environments_to_delete' parameter is required`);
+        });
+
+        it('should work when all required parameters are provided', function () {
+            let phaseConfig = {
+                environments_to_delete: ['dev']
+            };
+            let errors = handelDelete.check(phaseConfig);
+            expect(errors.length).to.equal(0);
+        });
+    });
+
+    describe('getSecretsForPhase', function () {
+        it('should return an empty object', function () {
+            return handelDelete.getSecretsForPhase()
+                .then(results => {
+                    expect(results).to.deep.equal({});
+                });
+        });
+    });
+
+    describe('createPhase', function () {
+        let phaseContext = {
+            appName: 'myApp',
+            accountConfig: {
+                account_id: 111111111111
+            },
+            params: {
+                environments_to_delete: ['dev']
+            }
+        }
+
+        let role = {
+            Arn: "FakeArn"
+        }
+
+        it('should create the codebuild project and return the phase config', function () {
+            let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve(role));
+            let createPolicyStub = sandbox.stub(iamCalls, 'createPolicyIfNotExists').returns(Promise.resolve(role));
+            let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
+            let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve(role));
+            let getProjectStub = sandbox.stub(codebuildCalls, 'getProject').returns(Promise.resolve(null));
+            let createProjectStub = sandbox.stub(codebuildCalls, 'createProject').returns(Promise.resolve)
+
+            return handelDelete.createPhase(phaseContext, {})
+                .then(phase => {
+                    expect(createRoleStub.calledOnce).to.be.true;
+                    expect(createPolicyStub.calledOnce).to.be.true;
+                    expect(attachPolicyStub.calledOnce).to.be.true;
+                    expect(getRoleStub.calledOnce).to.be.true;
+                    expect(getProjectStub.calledOnce).to.be.true;
+                    expect(createProjectStub.calledOnce).to.be.true;
+                });
+        });
+
+        it('should update the project when it already exists', function () {
+            let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve(role));
+            let createPolicyStub = sandbox.stub(iamCalls, 'createPolicyIfNotExists').returns(Promise.resolve(role));
+            let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
+            let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve(role));
+            let getProjectStub = sandbox.stub(codebuildCalls, 'getProject').returns(Promise.resolve({}));
+            let updateProjectStub = sandbox.stub(codebuildCalls, 'updateProject').returns(Promise.resolve)
+
+            return handelDelete.createPhase(phaseContext, {})
+                .then(phase => {
+                    expect(createRoleStub.calledOnce).to.be.true;
+                    expect(createPolicyStub.calledOnce).to.be.true;
+                    expect(attachPolicyStub.calledOnce).to.be.true;
+                    expect(getRoleStub.calledOnce).to.be.true;
+                    expect(getProjectStub.calledOnce).to.be.true;
+                    expect(updateProjectStub.calledOnce).to.be.true;
+                });
+        })
+    });
+
+    describe('deletePhase', function () {
+        let phaseContext = {
+            phaseName: 'FakePhase',
+            appName: 'FakeApp',
+            params: {
+                environments_to_delete: ['dev']
+            }
+        }
+        it('should delete the codebuild project', function () {
+            let deleteProjectStub = sandbox.stub(codebuildCalls, 'deleteProject').returns(Promise.resolve(true))
+            return handelDelete.deletePhase(phaseContext, {})
+                .then(result => {
+                    expect(result).to.be.true;
+                    expect(deleteProjectStub.calledOnce).to.be.true;
+                });
+        });
+    });
+});


### PR DESCRIPTION
This phase deletes an environment that was previously created in
a pipeline. This is intended for use in ephemeral environments that
only need to persist during something like tests in a pipeline.

There's a giant warning in the docs for this phase that state how
dangerous this phase is, because it deletes all data.

Resolves #41 