### PR TITLE
Add support for CodeCommit source type

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Handel-CodePipeline is a tool to easily create AWS CodePipelines, including supp
    phase-types/approval
    phase-types/github
    phase-types/codebuild
+   phase-types/codecommit
    phase-types/handel
    phase-types/handel_delete
    phase-types/runscope

--- a/docs/phase-types/codecommit.rst
+++ b/docs/phase-types/codecommit.rst
@@ -1,0 +1,48 @@
+CodeCommit
+==========
+The *CodeCommit* phase type configures a pipeline phase to pull source code from CodeCommit. The pipeline is launched when code is pushed to CodeCommit on the specified branch. The first phase of every pipeline created with Handel-CodePipeline must be a source code phase such as this CodeCommit type. 
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - repo 
+     - string
+     - Yes
+     - 
+     - The name of the CodeCommit repository containing the source code that will build and deploy in the pipeline.
+   * - branch
+     - string
+     - No
+     - master
+     - The name of the Git branch in the repository from which the pipeline will be invoked.
+
+Secrets
+-------
+This phase type doesn't prompt for any secrets when creating the pipeline.
+
+
+Example Phase Configuration
+---------------------------
+This snippet of a handel-codepipeline.yml file shows the CodeCommit phase being configured:
+
+.. code-block:: yaml
+    
+    version: 1
+
+    pipelines:
+      dev:
+        phases:
+        - type: codecommit
+          name: Source
+          owner: byu-oit-appdev
+          repo: aws-credential-detector
+          branch: master
+        ...

--- a/lib/lifecycle/index.js
+++ b/lib/lifecycle/index.js
@@ -71,8 +71,8 @@ exports.validatePipelineSpec = function (handelCodePipelineFile) {
                     errors.push(`You must specify at least two phases: github and codebuild`);
                 }
                 else {
-                    if (pipelineDef.phases[0].type !== 'github') {
-                        errors.push(`The first phase in your pipeline ${pipelineName} must be a github phase`)
+                    if (pipelineDef.phases[0].type !== 'github' && pipelineDef.phases[0].type !== 'codecommit') {
+                        errors.push(`The first phase in your pipeline ${pipelineName} must be a 'github' or 'codecommit' phase`)
                     }
                     if (pipelineDef.phases[1].type !== 'codebuild') {
                         errors.push(`The second phase in your application ${pipelineName} must be a codebuild phase`);

--- a/lib/phases/codecommit/index.js
+++ b/lib/phases/codecommit/index.js
@@ -1,0 +1,54 @@
+const winston = require('winston');
+
+exports.check = function (phaseConfig) {
+    let errors = [];
+
+    if (!phaseConfig.repo) {
+        errors.push(`GitHub - The 'repo' parameter is required`);
+    }
+    if (!phaseConfig.branch) {
+        errors.push(`GitHub - The 'branch' parameter is required`);
+    }
+
+    return errors;
+}
+
+exports.getSecretsForPhase = function () {
+    return Promise.resolve({});
+}
+
+exports.createPhase = function (phaseContext, accountConfig) {
+    winston.info(`Creating source phase '${phaseContext.phaseName}'`);
+    let branch = phaseContext.params.branch || "master";
+
+    return Promise.resolve({
+        name: phaseContext.phaseName,
+        actions: [
+            {
+                inputArtifacts: [],
+                name: phaseContext.phaseName,
+                actionTypeId: {
+                    category: "Source",
+                    owner: "AWS",
+                    version: "1",
+                    provider: "CodeCommit"
+                },
+                outputArtifacts: [
+                    {
+                        name: `Output_Source`
+                    }
+                ],
+                configuration: {
+                    RepositoryName: phaseContext.params.repo,
+                    BranchName: branch
+                },
+                runOrder: 1
+            }
+        ]
+    });
+}
+
+exports.deletePhase = function (phaseContext, accountConfig) {
+    winston.info(`Nothing to delete for source phase '${phaseContext.phaseName}'`);
+    return Promise.resolve({}); //Nothing to delete
+}

--- a/test/lifecycle/lifecycle-test.js
+++ b/test/lifecycle/lifecycle-test.js
@@ -117,7 +117,7 @@ describe('lifecycle module', function () {
             expect(errors[0]).to.contain("You must specify at least two phases");
         });
 
-        it('should return an error if the first phase is not a github phase', function () {
+        it('should return an error if the first phase is not a github or codecommit phase', function () {
             let handelCodePipelineFile = {
                 version: 1,
                 name: 'my-pipeline',
@@ -140,7 +140,7 @@ describe('lifecycle module', function () {
 
             let errors = lifecycle.validatePipelineSpec(handelCodePipelineFile);
             expect(errors.length).to.equal(1);
-            expect(errors[0]).to.contain("must be a github phase");
+            expect(errors[0]).to.contain("must be a 'github' or 'codecommit' phase");
         });
 
         it('should return an error if the second phase is not a codebuild phase', function () {

--- a/test/phases/codecommit/codecommit-test.js
+++ b/test/phases/codecommit/codecommit-test.js
@@ -1,0 +1,81 @@
+const codecommit = require('../../../lib/phases/codecommit');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+describe('github phase module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('check', function () {
+        it('should require the repo parameter', function() {
+            let phaseConfig = {
+                branch: 'FakeBranch'
+            };
+            let errors = codecommit.check(phaseConfig);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.include(`The 'repo' parameter is required`);
+        });
+
+        it('should require the branch parameter', function() {
+            let phaseConfig = {
+                repo: 'FakeRepo'
+            };
+            let errors = codecommit.check(phaseConfig);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.include(`The 'branch' parameter is required`);
+        });
+
+        it('should work when all required parameters are provided', function () {
+            let phaseConfig = {
+                repo: 'FakeRepo',
+                branch: 'FakeBranch'
+            };
+            let errors = codecommit.check(phaseConfig);
+            expect(errors.length).to.equal(0);
+        });
+    });
+
+    describe('getSecretsForPhase', function () {
+        it('should return an empty object', function () {
+            return codecommit.getSecretsForPhase()
+                .then(results => {
+                    expect(results).to.deep.equal({});
+                });
+        });
+    });
+
+    describe('createPhase', function () {
+        it('should create the codebuild project and return the phase config', function () {
+            let phaseContext = {
+                phaseName: 'myphase',
+                appName: 'myApp',
+                accountConfig: {
+                    account_id: 111111111111
+                },
+                params: {},
+                secrets: {}
+            }
+
+            return codecommit.createPhase(phaseContext, {})
+                .then(phase => {
+                    expect(phase.name).to.equal(phaseContext.phaseName);
+                });
+        });
+    });
+
+    describe('deletePhase', function () {
+        it('should do nothing', function () {
+            return codecommit.deletePhase({}, {})
+                .then(result => {
+                    expect(result).to.deep.equal({});
+                })
+        });
+    });
+});


### PR DESCRIPTION
This change adds support for the CodeCommit source code repository
type. It was pretty trivial to add since AWS integrates CodeCommit
and CodePipeline quite well.

Resolves #37 