### PR TITLE
Multiple phase types work and don't delete account-wide Lambdas.

### DIFF
--- a/bin/handel-codepipeline
+++ b/bin/handel-codepipeline
@@ -1,10 +1,4 @@
 #!/usr/bin/env node
-const AWS = require('aws-sdk');
-const input = require('../lib/input');
-const winston = require('winston');
-const util = require('../lib/util/util');
-const lifecycle = require('../lib/lifecycle');
-const s3Calls = require('../lib/aws/s3-calls');
 const yaml = require('js-yaml');
 const fs = require('fs');
 const cli = require('../lib/cli');

--- a/lib/aws/codebuild-calls.js
+++ b/lib/aws/codebuild-calls.js
@@ -1,5 +1,4 @@
 const AWS = require('aws-sdk');
-const winston = require('winston');
 
 function getCodeBuildEnvVarDef(key, value) {
     return {

--- a/lib/aws/codepipeline-calls.js
+++ b/lib/aws/codepipeline-calls.js
@@ -4,6 +4,10 @@ const winston = require('winston');
 
 let CODEPIPELINE_ROLE_NAME = 'HandelCodePipelineServiceRole';
 
+function getPipelineProjectName(appName, pipelineName) {
+    return `${appName}-${pipelineName}`;
+}
+
 function createCodePipelineRole(accountId) {
 
     return iamCalls.createRoleIfNotExists(CODEPIPELINE_ROLE_NAME, 'codepipeline.amazonaws.com')
@@ -105,11 +109,11 @@ function createPipeline(codePipeline, createParams) {
     return deferred.promise;
 }
 
-function getPipelineConfig(projectName, codePipelineBucketName, codePipelinePhases, codePipelineRole) {
+function getPipelineConfig(pipelineProjectName, codePipelineBucketName, codePipelinePhases, codePipelineRole) {
     let pipelineConfig = {
         pipeline: {
             version: 1,
-            name: projectName,
+            name: pipelineProjectName,
             artifactStore: {
                 type: "S3",
                 location: codePipelineBucketName
@@ -125,10 +129,10 @@ function getPipelineConfig(projectName, codePipelineBucketName, codePipelinePhas
     return pipelineConfig;
 }
 
-function createCodePipelineProject(codePipeline, accountId, projectName, codePipelineBucketName, codePipelinePhases) {
+function createCodePipelineProject(codePipeline, accountId, pipelineProjectName, codePipelineBucketName, codePipelinePhases) {
     return createCodePipelineRole(accountId)
         .then(codePipelineRole => {
-            let pipelineConfig = getPipelineConfig(projectName, codePipelineBucketName, codePipelinePhases, codePipelineRole);
+            let pipelineConfig = getPipelineConfig(pipelineProjectName, codePipelineBucketName, codePipelinePhases, codePipelineRole);
 
             return createPipeline(codePipeline, pipelineConfig)
                 .then(createResult => {
@@ -140,9 +144,10 @@ function createCodePipelineProject(codePipeline, accountId, projectName, codePip
 exports.createPipeline = function (appName, pipelineName, accountConfig, pipelinePhases, codePipelineBucketName) {
     const codePipeline = new AWS.CodePipeline({ apiVersion: '2015-07-09' });
     let accountId = accountConfig.account_id;
+    let pipelineProjectName = getPipelineProjectName(appName, pipelineName);
 
-    winston.info(`Creating CodePipeline for the pipeline '${pipelineName}'`);
-    return createCodePipelineProject(codePipeline, accountId, appName, codePipelineBucketName, pipelinePhases);
+    winston.info(`Creating CodePipeline for the pipeline '${pipelineProjectName}'`);
+    return createCodePipelineProject(codePipeline, accountId, pipelineProjectName, codePipelineBucketName, pipelinePhases);
 }
 
 exports.getPipeline = function(pipelineName) {
@@ -164,10 +169,11 @@ exports.getPipeline = function(pipelineName) {
 
 exports.updatePipeline = function (appName, pipelineName, accountConfig, pipelinePhases, codePipelineBucketName) {
     const codePipeline = new AWS.CodePipeline({ apiVersion: '2015-07-09' });
+    let pipelineProjectName = getPipelineProjectName(appName, pipelineName);
 
     return iamCalls.getRole(CODEPIPELINE_ROLE_NAME)
         .then(codePipelineRole => {
-            let pipelineConfig = getPipelineConfig(appName, codePipelineBucketName, pipelinePhases, codePipelineRole);
+            let pipelineConfig = getPipelineConfig(pipelineProjectName, codePipelineBucketName, pipelinePhases, codePipelineRole);
             return codePipeline.updatePipeline(pipelineConfig).promise()
                 .then(updateResult => {
                     return updateResult.pipeline;
@@ -175,10 +181,11 @@ exports.updatePipeline = function (appName, pipelineName, accountConfig, pipelin
         });
 }
 
-exports.deletePipeline = function (pipelineName) {
+exports.deletePipeline = function (appName, pipelineName) {
     const codePipeline = new AWS.CodePipeline({ apiVersion: '2015-07-09' });
+    let pipelineProjectName = getPipelineProjectName(appName, pipelineName)
     var deleteParams = {
-        name: pipelineName
+        name: pipelineProjectName
     };
     return codePipeline.deletePipeline(deleteParams).promise()
         .then(deleteResult => {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -47,22 +47,21 @@ exports.createAction = function (handelCodePipelineFile) {
             let accountName = pipelineConfig.accountName;
             let accountConfig = util.getAccountConfig(pipelineConfig.accountConfigsPath, accountName);
             AWS.config.update({ region: accountConfig.region });
-            let pipelineToCreate = pipelineConfig.pipelineToCreate;
+            let pipelineName = pipelineConfig.pipelineToCreate;
 
             let codePipelineBucketName = getCodePipelineBucketName(accountConfig);
             return s3Calls.createBucketIfNotExists(codePipelineBucketName, accountConfig.region)
                 .then(bucket => {
-                    return lifecycle.getPhaseSecrets(phaseDeployers, handelCodePipelineFile, pipelineToCreate)
+                    return lifecycle.getPhaseSecrets(phaseDeployers, handelCodePipelineFile, pipelineName)
                         .then(phasesSecrets => {
-                            return lifecycle.createPhases(phaseDeployers, handelCodePipelineFile, pipelineToCreate, accountConfig, phasesSecrets, codePipelineBucketName)
+                            return lifecycle.createPhases(phaseDeployers, handelCodePipelineFile, pipelineName, accountConfig, phasesSecrets, codePipelineBucketName)
                         })
                         .then(pipelinePhases => {
-                            return lifecycle.createPipeline(handelCodePipelineFile, pipelineToCreate, accountConfig, pipelinePhases, codePipelineBucketName);
+                            return lifecycle.createPipeline(handelCodePipelineFile, pipelineName, accountConfig, pipelinePhases, codePipelineBucketName);
                         })
                         .then(pipeline => {
                             winston.info(`Finished creating pipeline in ${accountConfig.account_id}`);
                         });
-
                 })
         })
         .catch(err => {
@@ -89,12 +88,12 @@ exports.deleteAction = function (handelCodePipelineFile) {
             let accountConfig = util.getAccountConfig(pipelineConfig.accountConfigsPath, accountName);
             AWS.config.update({ region: accountConfig.region });
             let codePipelineBucketName = getCodePipelineBucketName(accountConfig);
-            let pipelineToDelete = pipelineConfig.pipelineToDelete;
+            let pipelineName = pipelineConfig.pipelineToDelete;
             let appName = handelCodePipelineFile.name
 
-            return lifecycle.deletePipeline(appName)
+            return lifecycle.deletePipeline(appName, pipelineName)
                 .then(deleteResult => {
-                    return lifecycle.deletePhases(phaseDeployers, handelCodePipelineFile, pipelineToDelete, accountConfig, codePipelineBucketName)
+                    return lifecycle.deletePhases(phaseDeployers, handelCodePipelineFile, pipelineName, accountConfig, codePipelineBucketName)
                 })
                 .catch(err => {
                     winston.error(`Error deleting Handel CodePipeline: ${err}`);

--- a/lib/lifecycle/index.js
+++ b/lib/lifecycle/index.js
@@ -95,11 +95,11 @@ exports.validatePipelineSpec = function (handelCodePipelineFile) {
     return errors;
 }
 
-exports.getPhaseSecrets = function (phaseDeployers, handelCodePipelineFile, pipelineToCreate) {
+exports.getPhaseSecrets = function (phaseDeployers, handelCodePipelineFile, pipelineName) {
     return new Promise((resolve, reject) => {
         let inputFunctions = [];
 
-        for (let phaseSpec of handelCodePipelineFile.pipelines[pipelineToCreate].phases) {
+        for (let phaseSpec of handelCodePipelineFile.pipelines[pipelineName].phases) {
             let phaseType = phaseSpec.type;
             let phaseDeployer = phaseDeployers[phaseType];
             inputFunctions.push(function (callback) {
@@ -109,7 +109,7 @@ exports.getPhaseSecrets = function (phaseDeployers, handelCodePipelineFile, pipe
                     })
                     .catch(err => {
                         callback(err, null);
-                    })
+                    });
             });
         }
 
@@ -124,14 +124,14 @@ exports.getPhaseSecrets = function (phaseDeployers, handelCodePipelineFile, pipe
     });
 }
 
-exports.createPhases = function (phaseDeployers, handelCodePipelineFile, pipelineToCreate, accountConfig, phasesSecrets, codePipelineBucketName) {
+exports.createPhases = function (phaseDeployers, handelCodePipelineFile, pipelineName, accountConfig, phasesSecrets, codePipelineBucketName) {
     let createPromises = [];
 
-    let pipelinePhases = handelCodePipelineFile.pipelines[pipelineToCreate].phases
+    let pipelinePhases = handelCodePipelineFile.pipelines[pipelineName].phases
     for (let i = 0; i < pipelinePhases.length; i++) {
         let phase = pipelinePhases[i];
 
-        let phaseContext = getPhaseContext(handelCodePipelineFile, codePipelineBucketName, pipelineToCreate, accountConfig, phase, phasesSecrets[i]);
+        let phaseContext = getPhaseContext(handelCodePipelineFile, codePipelineBucketName, pipelineName, accountConfig, phase, phasesSecrets[i]);
 
         createPromises.push(createPhase(phaseContext, phaseDeployers, accountConfig));
     }
@@ -139,31 +139,30 @@ exports.createPhases = function (phaseDeployers, handelCodePipelineFile, pipelin
     return Promise.all(createPromises);
 }
 
-exports.createPipeline = function (handelCodePipelineFile, pipelineToCreate, accountConfig, pipelinePhases, codePipelineBucketName) {
-    let pipelineDefinition = handelCodePipelineFile.pipelines[pipelineToCreate];
+exports.createPipeline = function (handelCodePipelineFile, pipelineName, accountConfig, pipelinePhases, codePipelineBucketName) {
     let appName = handelCodePipelineFile.name;
 
     return codepipelineCalls.getPipeline(appName)
         .then(pipeline => {
             if (!pipeline) {
-                return codepipelineCalls.createPipeline(appName, pipelineToCreate, accountConfig, pipelinePhases, codePipelineBucketName);
+                return codepipelineCalls.createPipeline(appName, pipelineName, accountConfig, pipelinePhases, codePipelineBucketName);
             }
             else {
-                return codepipelineCalls.updatePipeline(appName, pipelineToCreate, accountConfig, pipelinePhases, codePipelineBucketName);
+                return codepipelineCalls.updatePipeline(appName, pipelineName, accountConfig, pipelinePhases, codePipelineBucketName);
             }
         });
 }
 
-exports.deletePhases = function (phaseDeployers, handelCodePipelineFile, pipelineToDelete, accountConfig, codePipelineBucketName) {
+exports.deletePhases = function (phaseDeployers, handelCodePipelineFile, pipelineName, accountConfig, codePipelineBucketName) {
     let deletePromises = [];
 
-    let pipelinePhases = handelCodePipelineFile.pipelines[pipelineToDelete].phases
+    let pipelinePhases = handelCodePipelineFile.pipelines[pipelineName].phases
     for (let i = 0; i < pipelinePhases.length; i++) {
         let phase = pipelinePhases[i];
         let phaseType = phase.type;
         let phaseDeloyer = phaseDeployers[phaseType];
 
-        let phaseContext = getPhaseContext(handelCodePipelineFile, codePipelineBucketName, pipelineToDelete, accountConfig, phase, {}); //Don't need phase secrets for delete
+        let phaseContext = getPhaseContext(handelCodePipelineFile, codePipelineBucketName, pipelineName, accountConfig, phase, {}); //Don't need phase secrets for delete
 
         deletePromises.push(phaseDeloyer.deletePhase(phaseContext, accountConfig));
     }
@@ -173,7 +172,7 @@ exports.deletePhases = function (phaseDeployers, handelCodePipelineFile, pipelin
 
 
 
-exports.deletePipeline = function (pipelineName) {
-    return codepipelineCalls.deletePipeline(pipelineName);
+exports.deletePipeline = function (appName, pipelineName) {
+    return codepipelineCalls.deletePipeline(appName, pipelineName);
 }
 

--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -3,8 +3,8 @@ const codeBuildCalls = require('../../aws/codebuild-calls');
 const winston = require('winston');
 const util = require('../../util/util');
 
-function getBuildProjectName(appName) {
-    return `${appName}-build`;
+function getBuildProjectName(phaseContext) {
+    return `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`;
 }
 
 function createBuildPhaseServiceRole(accountConfig, appName) {
@@ -32,18 +32,18 @@ function createBuildPhaseServiceRole(accountConfig, appName) {
 
 function createBuildPhaseCodeBuildProject(phaseContext) {
     let appName = phaseContext.appName;
-    let buildProjectName = getBuildProjectName(appName);
+    let buildProjectName = getBuildProjectName(phaseContext);
 
     return createBuildPhaseServiceRole(phaseContext.accountConfig, appName)
         .then(buildPhaseRole => {
             return codeBuildCalls.getProject(buildProjectName)
                 .then(buildProject => {
                     if (!buildProject) {
-                        winston.info(`Creating build phase CodeBuild project ${appName}`);
+                        winston.info(`Creating build phase CodeBuild project ${buildProjectName}`);
                         return codeBuildCalls.createProject(buildProjectName, appName, phaseContext.params.build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
                     }
                     else {
-                        winston.info(`Updating build phase CodeBuild project ${appName}`);
+                        winston.info(`Updating build phase CodeBuild project ${buildProjectName}`);
                         return codeBuildCalls.updateProject(buildProjectName, appName, phaseContext.params.build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region)
                     }
                 });
@@ -74,7 +74,7 @@ function getCodePipelinePhaseSpec(phaseContext) {
                     }
                 ],
                 configuration: {
-                    ProjectName: getBuildProjectName(phaseContext.appName)
+                    ProjectName: getBuildProjectName(phaseContext)
                 },
                 runOrder: 1
             }
@@ -104,7 +104,7 @@ exports.createPhase = function (phaseContext, accountConfig) {
 }
 
 exports.deletePhase = function (phaseContext, accountConfig) {
-    winston.info(`Delete CodeBuild project for '${phaseContext.phaseName}'`);
-    let codeBuildProjectName = getBuildProjectName(phaseContext.appName);
+    let codeBuildProjectName = getBuildProjectName(phaseContext);
+    winston.info(`Deleting CodeBuild project '${codeBuildProjectName}'`);
     return codeBuildCalls.deleteProject(codeBuildProjectName);
 }

--- a/lib/phases/handel/index.js
+++ b/lib/phases/handel/index.js
@@ -3,8 +3,8 @@ const codeBuildCalls = require('../../aws/codebuild-calls');
 const util = require('../../util/util');
 const winston = require('winston');
 
-function getDeployProjectName(appName, envsToDeploy) {
-    return `${appName}-deploy-${envsToDeploy.join("-")}`
+function getDeployProjectName(phaseContext) {
+    return `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`
 }
 
 function createDeployPhaseServiceRole(accountId) {
@@ -25,7 +25,7 @@ function createDeployPhaseServiceRole(accountId) {
 
 function createDeployPhaseCodeBuildProject(phaseContext, accountConfig) {
     let appName = phaseContext.appName;
-    let deployProjectName = getDeployProjectName(appName, phaseContext.params.environments_to_deploy)
+    let deployProjectName = getDeployProjectName(phaseContext)
     return createDeployPhaseServiceRole(phaseContext.accountConfig.account_id)
         .then(deployPhaseRole => {
             let handelDeployEnvVars = {
@@ -67,7 +67,7 @@ function getCodePipelinePhaseSpec(phaseContext) {
                     provider: "CodeBuild"
                 },
                 configuration: {
-                    ProjectName: getDeployProjectName(phaseContext.appName, phaseContext.params.environments_to_deploy)
+                    ProjectName: getDeployProjectName(phaseContext)
                 },
                 runOrder: 1
             }
@@ -97,7 +97,7 @@ exports.createPhase = function (phaseContext, accountConfig) {
 }
 
 exports.deletePhase = function (phaseContext, accountConfig) {
-    winston.info(`Delete CodeBuild project for '${phaseContext.phaseName}'`);
-    let codeBuildProjectName = getDeployProjectName(phaseContext.appName, phaseContext.params.environments_to_deploy);
+    let codeBuildProjectName = getDeployProjectName(phaseContext);
+    winston.info(`Delete CodeBuild project for '${codeBuildProjectName}'`);
     return codeBuildCalls.deleteProject(codeBuildProjectName);
 }

--- a/lib/phases/handel_delete/index.js
+++ b/lib/phases/handel_delete/index.js
@@ -3,8 +3,8 @@ const codeBuildCalls = require('../../aws/codebuild-calls');
 const util = require('../../util/util');
 const winston = require('winston');
 
-function getDeleteProjectName(appName, envsToDelete) {
-    return `${appName}-delete-${envsToDelete.join("-")}`
+function getDeleteProjectName(phaseContext) {
+    return `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`
 }
 
 function createDeletePhaseServiceRole(accountId) {
@@ -25,7 +25,7 @@ function createDeletePhaseServiceRole(accountId) {
 
 function createDeletePhaseCodeBuildProject(phaseContext, accountConfig) {
     let appName = phaseContext.appName;
-    let deleteProjectName = getDeleteProjectName(appName, phaseContext.params.environments_to_delete)
+    let deleteProjectName = getDeleteProjectName(phaseContext)
     return createDeletePhaseServiceRole(phaseContext.accountConfig.account_id)
         .then(deletePhaseRole => {
             let handelDeleteEnvVars = {
@@ -67,7 +67,7 @@ function getCodePipelinePhaseSpec(phaseContext) {
                     provider: "CodeBuild"
                 },
                 configuration: {
-                    ProjectName: getDeleteProjectName(phaseContext.appName, phaseContext.params.environments_to_delete)
+                    ProjectName: getDeleteProjectName(phaseContext)
                 },
                 runOrder: 1
             }
@@ -97,7 +97,7 @@ exports.createPhase = function (phaseContext, accountConfig) {
 }
 
 exports.deletePhase = function (phaseContext, accountConfig) {
-    winston.info(`Delete CodeBuild project for '${phaseContext.phaseName}'`);
-    let codeBuildProjectName = getDeleteProjectName(phaseContext.appName, phaseContext.params.environments_to_delete);
+    let codeBuildProjectName = getDeleteProjectName(phaseContext);
+    winston.info(`Delete CodeBuild project for '${codeBuildProjectName}'`);
     return codeBuildCalls.deleteProject(codeBuildProjectName);
 }

--- a/lib/phases/runscope/index.js
+++ b/lib/phases/runscope/index.js
@@ -100,16 +100,7 @@ exports.createPhase = function (phaseContext, accountConfig) {
 }
 
 exports.deletePhase = function (phaseContext, accountConfig) {
-    return cloudformationCalls.getStack(STACK_NAME)
-        .then(stack => {
-            if (stack) {
-                winston.info(`Deleting Lambda for '${phaseContext.phaseName}'`);
-                return cloudformationCalls.deleteStack(STACK_NAME);
-            }
-            else {
-                winston.info(`Lambda for '${phaseContext.phaseName}' was already deleted`);
-                return true;
-            }
-        });
+    winston.info(`Nothing to delete for runscope phase '${phaseContext.phaseName}'`);
+    return Promise.resolve({}); //Nothing to delete
 }
 

--- a/lib/phases/slack_notify/index.js
+++ b/lib/phases/slack_notify/index.js
@@ -103,15 +103,6 @@ exports.createPhase = function (phaseContext, accountConfig) {
 }
 
 exports.deletePhase = function (phaseContext, accountConfig) {
-    return cloudformationCalls.getStack(STACK_NAME)
-        .then(stack => {
-            if (stack) {
-                winston.info(`Deleting Lambda for '${phaseContext.phaseName}'`);
-                return cloudformationCalls.deleteStack(STACK_NAME);
-            }
-            else {
-                winston.info(`Lambda for '${phaseContext.phaseName}' was already deleted`);
-                return true;
-            }
-        });
+    winston.info(`Nothing to delete for slack_notify phase '${phaseContext.phaseName}'`);
+    return Promise.resolve({}); //Nothing to delete
 }

--- a/test/aws/codepipeline-calls-test.js
+++ b/test/aws/codepipeline-calls-test.js
@@ -98,10 +98,10 @@ describe('codepipelineCalls module', function () {
         it('should delete the pipeline', function() {
             AWS.mock('CodePipeline', 'deletePipeline', Promise.resolve(true));
 
-            return codepipelineCalls.deletePipeline("FakePipeline")
+            return codepipelineCalls.deletePipeline("FakeApp", "FakePipeline")
                 .then(success => {
                     expect(success).to.equal(true);
-                })
+                });
         });
     });
 });

--- a/test/cli/cli-test.js
+++ b/test/cli/cli-test.js
@@ -1,0 +1,4 @@
+const expect = require('chai').expect;
+const AWS = require('aws-sdk-mock');
+const cli = require('../../lib/cli');
+const sinon = require('sinon');

--- a/test/lifecycle/lifecycle-test.js
+++ b/test/lifecycle/lifecycle-test.js
@@ -364,7 +364,7 @@ describe('lifecycle module', function () {
     describe('deletePipeline', function () {
         it('should delete the pipeline', function () {
             let deletePipelineStub = sandbox.stub(codepipelineCalls, 'deletePipeline').returns(Promise.resolve({}));
-            return lifecycle.deletePipeline("FakeName")
+            return lifecycle.deletePipeline("FakeApp", "FakePipeline")
                 .then(result => {
                     expect(result).to.deep.equal({});
                     expect(deletePipelineStub.calledOnce).to.be.true;

--- a/test/phases/runscope/runscope-test.js
+++ b/test/phases/runscope/runscope-test.js
@@ -103,29 +103,10 @@ describe('runscope module', function () {
     });
 
     describe('deletePhase', function () {
-        let phaseContext = {
-            phaseName: 'FakePhase'
-        }
-
-        it('should delete the cloudformation stack if present', function () {
-            let deleteStackStub = sandbox.stub(cloudFormationCalls, 'deleteStack').returns(Promise.resolve(true));
-            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({}));
-            return runscope.deletePhase(phaseContext, {})
+        it('should do nothing', function () {
+            return runscope.deletePhase({}, {})
                 .then(result => {
-                    expect(result).to.equal(true);
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(deleteStackStub.calledOnce).to.be.true;
-                });
-        });
-
-        it('should return true if the stack is already deleted', function () {
-            let deleteStackStub = sandbox.stub(cloudFormationCalls, 'deleteStack').returns(Promise.resolve(true));
-            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve(null));
-            return runscope.deletePhase(phaseContext, {})
-                .then(result => {
-                    expect(result).to.equal(true);
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(deleteStackStub.notCalled).to.be.true;
+                    expect(result).to.deep.equal({});
                 });
         });
     });

--- a/test/phases/slack_notify/slack-notify-test.js
+++ b/test/phases/slack_notify/slack-notify-test.js
@@ -119,29 +119,10 @@ describe('slack_notify module', function () {
     });
 
     describe('deletePhase', function () {
-        let phaseContext = {
-            phaseName: 'FakePhase'
-        }
-
-        it('should delete the cloudformation stack if present', function () {
-            let deleteStackStub = sandbox.stub(cloudFormationCalls, 'deleteStack').returns(Promise.resolve(true));
-            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({}));
-            return slackNotify.deletePhase(phaseContext, {})
+        it('should do nothing', function () {
+            return slackNotify.deletePhase({}, {})
                 .then(result => {
-                    expect(result).to.equal(true);
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(deleteStackStub.calledOnce).to.be.true;
-                });
-        });
-
-        it('should return true if the stack is already deleted', function () {
-            let deleteStackStub = sandbox.stub(cloudFormationCalls, 'deleteStack').returns(Promise.resolve(true));
-            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve(null));
-            return slackNotify.deletePhase(phaseContext, {})
-                .then(result => {
-                    expect(result).to.equal(true);
-                    expect(getStackStub.calledOnce).to.be.true;
-                    expect(deleteStackStub.notCalled).to.be.true;
+                    expect(result).to.deep.equal({});
                 });
         });
     });


### PR DESCRIPTION
This change makes sure that multiple phase types will work by
properly naming the CodeBuild and CodePipeline resources to support
multiple phases with different names.

This change also stops deleting the Lambdas for Runscope and Slack
Notify. These Lambdas are account-wide, and so should not be
deleted.

Resolves #40 
Resolves #50 