### PR TITLE
Added support for custom build images in ECR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vscode/
+.idea/
 docs/_build/
 node_modules/
 npm-debug.log

--- a/docs/phase-types/codebuild.rst
+++ b/docs/phase-types/codebuild.rst
@@ -6,7 +6,7 @@ Build Configuration
 -------------------
 You can specify any arbitrary build process in this phase using the `buildspec.yml file <http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html>`_. You must have this *buildspec.yml* file in the root of your repository or the CodeBuild phase will fail.
 
-You can use a custom build image in ECR by prefixing the build_image parameter with 'custom/'. Example: custom/IMAGE:TAG. This resolves to AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com/IMAGE:TAG
+You can use a custom build image in ECR by prefixing the build_image parameter with '<account>/'. Example: <account>/IMAGE:TAG. This resolves to AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com/IMAGE:TAG . Please be aware that templating of this sort using <*> is only avaibale in the CodeBuild phase as part of the build_image parameter
 Using a custom build image also configures the Codebuild instance to run Docker in Docker. Using Docker in Docker in a custom build image requires specific configuration in buildspec.yml. See this `user guide <http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html>`_ for more details. 
 
 Parameters

--- a/docs/phase-types/codebuild.rst
+++ b/docs/phase-types/codebuild.rst
@@ -6,6 +6,9 @@ Build Configuration
 -------------------
 You can specify any arbitrary build process in this phase using the `buildspec.yml file <http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html>`_. You must have this *buildspec.yml* file in the root of your repository or the CodeBuild phase will fail.
 
+You can use a custom build image in ECR by prefixing the build_image parameter with 'custom/'. Example: custom/IMAGE:TAG. This resolves to AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com/IMAGE:TAG
+Using a custom build image also configures the Codebuild instance to run Docker in Docker. Using Docker in Docker in a custom build image requires specific configuration in buildspec.yml. See this `user guide <http://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html>`_ for more details. 
+
 Parameters
 ----------
 

--- a/lib/aws/codebuild-calls.js
+++ b/lib/aws/codebuild-calls.js
@@ -76,6 +76,12 @@ function getProjectParams(projectName, appName, imageName, environmentVariables,
         ]
     }
 
+    //If using a custom image, set the build to use privilegedMode. Allows access to docker daemon for docker build
+    //http://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectEnvironment.html
+    if(imageName.startsWith(accountId)){
+        projectParams.environment.privilegedMode = true;
+    }
+
         //Override buildspec if specified
     if (buildSpec) {
         projectParams.source.buildspec = buildSpec;

--- a/lib/phases/codebuild/build-phase-service-policy.json
+++ b/lib/phases/codebuild/build-phase-service-policy.json
@@ -59,6 +59,20 @@
                 "ssm:GetParameters"
             ],
             "Resource": "arn:aws:ssm:{{region}}:{{accountId}}:parameter/{{appName}}*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:DescribeRepositories"
+            ],
+            "Resource" : "arn:aws:ecr:{{region}}:{{accountId}}:repository/{{appName}}*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:CreateRepository"
+            ],
+            "Resource" : "*"
         }
     ]
 }

--- a/lib/phases/codebuild/build-phase-service-policy.json
+++ b/lib/phases/codebuild/build-phase-service-policy.json
@@ -65,7 +65,7 @@
             "Action": [
                 "ecr:DescribeRepositories"
             ],
-            "Resource" : "arn:aws:ecr:{{region}}:{{accountId}}:repository/{{appName}}*"
+            "Resource" : "*"
         },
         {
             "Effect": "Allow",

--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -49,6 +49,12 @@ function createBuildPhaseServiceRole(accountConfig, appName) {
 function createBuildPhaseCodeBuildProject(phaseContext) {
     let appName = phaseContext.appName;
     let buildProjectName = getBuildProjectName(phaseContext);
+    let build_image = phaseContext.params.build_image;
+
+    if (build_image && build_image.startsWith('custom')) {
+        let image_name_and_tag = build_image.substring(7);
+        build_image = `${phaseContext.accountConfig.account_id}.dkr.ecr.${phaseContext.accountConfig.region}.amazonaws.com/${image_name_and_tag}`;
+    }
 
     return createBuildPhaseServiceRole(phaseContext.accountConfig, appName)
         .then(buildPhaseRole => {
@@ -56,11 +62,11 @@ function createBuildPhaseCodeBuildProject(phaseContext) {
                 .then(buildProject => {
                     if (!buildProject) {
                         winston.info(`Creating build phase CodeBuild project ${buildProjectName}`);
-                        return codeBuildCalls.createProject(buildProjectName, appName, phaseContext.params.build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
+                        return codeBuildCalls.createProject(buildProjectName, appName, build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
                     }
                     else {
                         winston.info(`Updating build phase CodeBuild project ${buildProjectName}`);
-                        return codeBuildCalls.updateProject(buildProjectName, appName, phaseContext.params.build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region)
+                        return codeBuildCalls.updateProject(buildProjectName, appName, build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region)
                     }
                 });
         });

--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -52,7 +52,7 @@ function createBuildPhaseCodeBuildProject(phaseContext) {
     let build_image = phaseContext.params.build_image;
 
     if (build_image && build_image.startsWith('<account>')) {
-        let image_name_and_tag = build_image.substring(7);
+        let image_name_and_tag = build_image.substring(9);
         build_image = `${phaseContext.accountConfig.account_id}.dkr.ecr.${phaseContext.accountConfig.region}.amazonaws.com/${image_name_and_tag}`;
     }
 

--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -51,7 +51,7 @@ function createBuildPhaseCodeBuildProject(phaseContext) {
     let buildProjectName = getBuildProjectName(phaseContext);
     let build_image = phaseContext.params.build_image;
 
-    if (build_image && build_image.startsWith('custom')) {
+    if (build_image && build_image.startsWith('<account>')) {
         let image_name_and_tag = build_image.substring(7);
         build_image = `${phaseContext.accountConfig.account_id}.dkr.ecr.${phaseContext.accountConfig.region}.amazonaws.com/${image_name_and_tag}`;
     }


### PR DESCRIPTION
These changes allow the use of custom CodeBuild images from the accounts ECR repository. With these changes, prefixing the build image with 'custom/' will tell handel-codepipeline to look for the image in ECR. Doing so also configures the CodeBuild instance to allow its docker client to connect to the hosts docker daemon. This is useful when building a docker image as part of the build step. 

I added permissions to the CodeBuild policy to allow it to describe and create ECR repositories. This is required when pushing a docker image to an ECR repository as part of the build step. That repository may already exist, and if it does not, CodeBuild should then create that repository.