### PR TITLE
Add support for CloudFormation phase type

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,9 +17,10 @@ Handel-CodePipeline is a tool to easily create AWS CodePipelines, including supp
    :caption: Supported Pipeline Phase Types
 
    phase-types/approval
-   phase-types/github
+   phase-types/cloudformation
    phase-types/codebuild
    phase-types/codecommit
+   phase-types/github
    phase-types/handel
    phase-types/handel_delete
    phase-types/runscope

--- a/docs/phase-types/cloudformation.rst
+++ b/docs/phase-types/cloudformation.rst
@@ -1,0 +1,52 @@
+CloudFormation
+==============
+The *CloudFormation* phase type configures a pipeline phase to deploy a CloudFormation template
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - type
+     - string
+     - Yes
+     - cloudformation
+     - This must always be *cloudformation* for the CloudFormation phase type.
+   * - template_path
+     - string
+     - Yes
+     - 
+     - The path in your repository to your CloudFormation template.
+   * - deploy_role
+     - string
+     - Yes
+     -
+     - The role CloudFormation will use to create your role. This role must already exist in your account and must be assumable by CloudFormation.
+
+Secrets
+-------
+This phase type doesn't prompt for any secrets when creating the pipeline.
+
+Example Phase Configuration
+---------------------------
+This snippet of a handel-codepipeline.yml file shows the CloudFormation phase being configured:
+
+.. code-block:: yaml
+
+    version: 1
+
+    pipelines:
+      dev:
+        phases:
+        ...
+        - type: cloudformation
+          name: Deploy
+          template_path: cf-stack.yml
+          deploy_role: myservicerole
+        ...

--- a/lib/aws/codepipeline-calls.js
+++ b/lib/aws/codepipeline-calls.js
@@ -21,8 +21,7 @@ const winston = require('winston');
 let CODEPIPELINE_ROLE_NAME = 'HandelCodePipelineServiceRole';
 
 function createCodePipelineRole(accountId) {
-
-    return iamCalls.createRoleIfNotExists(CODEPIPELINE_ROLE_NAME, 'codepipeline.amazonaws.com')
+    return iamCalls.createRoleIfNotExists(CODEPIPELINE_ROLE_NAME, ['codepipeline.amazonaws.com', 'cloudformation.amazonaws.com'])
         .then(role => {
             let policyArn = `arn:aws:iam::${accountId}:policy/handel-codepipeline/${CODEPIPELINE_ROLE_NAME}`;
             let policyDocument = {
@@ -77,6 +76,41 @@ function createCodePipelineRole(accountId) {
                         Action: [
                             "codebuild:BatchGetBuilds",
                             "codebuild:StartBuild"
+                        ],
+                        Resource: "*",
+                        Effect: "Allow"
+                    },
+                    {
+                        Action: [
+                            "cloudformation:*"
+                        ],
+                        Resource: "*",
+                        Effect: "Allow"
+                    },
+                    {
+                        Action: [
+                            "iam:PassRole"
+                        ],
+                        Resource: "*",
+                        Effect: "Allow"
+                    },
+                    {
+                        Action: [
+                            "cloudwatch:*"
+                        ],
+                        Resource: "*",
+                        Effect: "Allow"
+                    },
+                    {
+                        Action: [
+                            "iam:DeleteRole"
+                        ],
+                        Resource: "*",
+                        Effect: "Allow"
+                    },
+                    {
+                        Action: [
+                            "iam:DeleteRolePolicy"
                         ],
                         Resource: "*",
                         Effect: "Allow"
@@ -153,7 +187,7 @@ function createCodePipelineProject(codePipeline, accountId, pipelineProjectName,
         });
 }
 
-exports.getPipelineProjectName = function(appName, pipelineName) {
+exports.getPipelineProjectName = function (appName, pipelineName) {
     return `${appName}-${pipelineName}`;
 }
 
@@ -166,19 +200,19 @@ exports.createPipeline = function (appName, pipelineName, accountConfig, pipelin
     return createCodePipelineProject(codePipeline, accountId, pipelineProjectName, codePipelineBucketName, pipelinePhases);
 }
 
-exports.getPipeline = function(pipelineName) {
+exports.getPipeline = function (pipelineName) {
     const codePipeline = new AWS.CodePipeline({ apiVersion: '2015-07-09' });
 
     let getParams = {
         name: pipelineName
     }
-    
+
     return codePipeline.getPipeline(getParams).promise()
         .then(result => {
             return result.pipeline;
         })
         .catch(err => {
-            if(err.code === 'PipelineNotFoundException') {
+            if (err.code === 'PipelineNotFoundException') {
                 return null; //No pipeline found   
             }
             throw err;

--- a/lib/aws/iam-calls.js
+++ b/lib/aws/iam-calls.js
@@ -16,7 +16,7 @@
  */
 const AWS = require('aws-sdk');
 
-exports.createRole = function(roleName, trustedService) {
+exports.createRole = function(roleName, trustedServices) {
     const iam = new AWS.IAM({apiVersion: '2010-05-08'});
     let assumeRolePolicyDoc = {
         "Version": "2012-10-17",
@@ -24,7 +24,7 @@ exports.createRole = function(roleName, trustedService) {
             {
                 "Effect": "Allow",
                 "Principal": {
-                    "Service": trustedService
+                    "Service": trustedServices
                 },
                 "Action": "sts:AssumeRole"
             }
@@ -58,11 +58,11 @@ exports.getRole = function(roleName) {
         });
 }
 
-exports.createRoleIfNotExists = function(roleName, trustedService) {
+exports.createRoleIfNotExists = function(roleName, trustedServices) {
     return exports.getRole(roleName)
         .then(role => {
             if(!role) {
-                return exports.createRole(roleName, trustedService);
+                return exports.createRole(roleName, trustedServices);
             }
             else {
                 return role;

--- a/lib/common/deployers-common.js
+++ b/lib/common/deployers-common.js
@@ -35,7 +35,7 @@ exports.uploadDirectoryToBucket = function(directoryToUpload, s3FileName, s3Buck
 
 exports.createLambdaCodePipelineRole = function(accountId) {
     let roleName = 'HandelCodePipelineLambdaRole';
-    return iamCalls.createRoleIfNotExists(roleName, 'lambda.amazonaws.com')
+    return iamCalls.createRoleIfNotExists(roleName, ['lambda.amazonaws.com'])
         .then(role => {
             let policyArn = `arn:aws:iam::${accountId}:policy/handel-codepipeline/${roleName}`;
             let policyDocument = {

--- a/lib/phases/cloudformation/index.js
+++ b/lib/phases/cloudformation/index.js
@@ -28,10 +28,10 @@ function getCloudFormationPhaseSpec(phaseContext, accountConfig) {
                 ],
                 name: phaseContext.phaseName,
                 actionTypeId: {
-                    Category: "Deploy",
-                    Owner: "AWS",
-                    Version: "1",
-                    Provider: "CloudFormation"
+                    category: "Deploy",
+                    owner: "AWS",
+                    version: "1",
+                    provider: "CloudFormation"
                 },
                 configuration: {
                     StackName: `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`,
@@ -55,10 +55,10 @@ function getCloudFormationPhaseSpec(phaseContext, accountConfig) {
 exports.check = function(phaseConfig) {
     let errors = [];
     
-    if (!phaseConfig.pararms.deploy_role) {
+    if (!phaseConfig.deploy_role) {
         errors.push("Cloudformation - The `deploy_role` parameter is required");
     }    
-    if (!phaseConfig.pararms.template_path) {
+    if (!phaseConfig.template_path) {
         errors.push("Cloudformation - The `template_path` parameter is required");
     }    
 

--- a/lib/phases/cloudformation/index.js
+++ b/lib/phases/cloudformation/index.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const winston = require('winston');
+
+function getCloudFormationPhaseSpec(phaseContext, accountConfig) {
+    var spec = {
+        name: phaseContext.phaseName,
+        actions: [
+            {
+                inputArtifacts: [
+                    {
+                        name: `Output_Build`
+                    }    
+                ],
+                name: phaseContext.phaseName,
+                actionTypeId: {
+                    Category: "Deploy",
+                    Owner: "AWS",
+                    Version: "1",
+                    Provider: "CloudFormation"
+                },
+                configuration: {
+                    StackName: `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`,
+                    ActionMode: "CREATE_UPDATE",
+                    Capabilities: "CAPABILITY_NAMED_IAM",
+                    RoleArn: `arn:aws:iam::${accountConfig.account_id}:role/${phaseContext.params.deploy_role}`, 
+                    TemplatePath: `Output_Build::${phaseContext.params.template_path}`
+                }
+            }
+        ],
+        
+    };
+    
+    if (phaseContext.params.template_parameters_path) {
+        spec.actions[0].configuration.TemplateConfiguration = `Output_Build::${phaseContext.params.template_parameters_path}`
+    }
+    
+    return spec;
+}
+
+exports.check = function(phaseConfig) {
+    let errors = [];
+    
+    if (!phaseConfig.pararms.deploy_role) {
+        errors.push("Cloudformation - The `deploy_role` parameter is required");
+    }    
+    if (!phaseConfig.pararms.template_path) {
+        errors.push("Cloudformation - The `template_path` parameter is required");
+    }    
+
+    return errors;
+}
+
+exports.getSecretsForPhase = function () {
+    return Promise.resolve({});
+}
+
+exports.createPhase = function (phaseContext, accountConfig) {
+    winston.info(`Creating CloudFormation phase '${phaseContext.phaseName}'`);
+
+    return Promise.resolve(getCloudFormationPhaseSpec(phaseContext, accountConfig));
+}
+
+exports.deletePhase = function(phaseContext, accountConfig) {
+    winston.info(`Nothing to delete for CloudFormation phase '${phaseContext.phaseName}'`);
+    return Promise.resolve({}); //Nothing to delete
+}

--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -25,7 +25,7 @@ function getBuildProjectName(phaseContext) {
 
 function createBuildPhaseServiceRole(accountConfig, appName) {
     let roleName = `${appName}-HandelCodePipelineBuildPhase`;
-    return iamCalls.createRoleIfNotExists(roleName, 'codebuild.amazonaws.com')
+    return iamCalls.createRoleIfNotExists(roleName, ['codebuild.amazonaws.com'])
         .then(role => {
             let policyArn = `arn:aws:iam::${accountConfig.account_id}:policy/handel-codepipeline/${roleName}`;
             let policyDocParams = {

--- a/lib/phases/handel/index.js
+++ b/lib/phases/handel/index.js
@@ -25,7 +25,7 @@ function getDeployProjectName(phaseContext) {
 
 function createDeployPhaseServiceRole(accountId) {
     let roleName = 'HandelCodePipelineDeployPhaseServiceRole'
-    return iamCalls.createRoleIfNotExists(roleName, 'codebuild.amazonaws.com')
+    return iamCalls.createRoleIfNotExists(roleName, ['codebuild.amazonaws.com'])
         .then(role => {
             let policyArn = `arn:aws:iam::${accountId}:policy/handel-codepipeline/${roleName}`;
             let policyDocument = util.loadJsonFile(`${__dirname}/deploy-phase-service-policy.json`);

--- a/lib/phases/handel_delete/index.js
+++ b/lib/phases/handel_delete/index.js
@@ -25,7 +25,7 @@ function getDeleteProjectName(phaseContext) {
 
 function createDeletePhaseServiceRole(accountId) {
     let roleName = 'HandelCodePipelineDeletePhaseServiceRole'
-    return iamCalls.createRoleIfNotExists(roleName, 'codebuild.amazonaws.com')
+    return iamCalls.createRoleIfNotExists(roleName, ['codebuild.amazonaws.com'])
         .then(role => {
             let policyArn = `arn:aws:iam::${accountId}:policy/handel-codepipeline/${roleName}`;
             let policyDocument = util.loadJsonFile(`${__dirname}/delete-phase-service-policy.json`);

--- a/test/aws/iam-calls-test.js
+++ b/test/aws/iam-calls-test.js
@@ -89,7 +89,7 @@ describe('iam calls', function() {
             sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve(null));
             sandbox.stub(iamCalls, 'createRole').returns(Promise.resolve({}));
 
-            return iamCalls.createRoleIfNotExists("FakeRole", "TrustedService")
+            return iamCalls.createRoleIfNotExists("FakeRole", ["TrustedService"])
                 .then(role => {
                     expect(role).to.deep.equal({});
                 });
@@ -98,7 +98,7 @@ describe('iam calls', function() {
         it('should just return the role when it already exists', function() {
             sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve({}));
 
-            return iamCalls.createRoleIfNotExists("FakeRole", "TrustedService")
+            return iamCalls.createRoleIfNotExists("FakeRole", ["TrustedService"])
                 .then(role => {
                     expect(role).to.deep.equal({});
                 });


### PR DESCRIPTION
This change adds support for the CloudFormation phase type. It is of course advised to use Handel since it's easier, but this works well for people who already have a CloudFormation template, or who need features that Handel doesn't support.

Resolves #61 