### PR TITLE
Fix bug where double-slash would get appended to image name.

### DIFF
--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -49,11 +49,11 @@ function createBuildPhaseServiceRole(accountConfig, appName) {
 function createBuildPhaseCodeBuildProject(phaseContext) {
     let appName = phaseContext.appName;
     let buildProjectName = getBuildProjectName(phaseContext);
-    let build_image = phaseContext.params.build_image;
+    let buildImage = phaseContext.params.build_image;
 
-    if (build_image && build_image.startsWith('<account>')) {
-        let image_name_and_tag = build_image.substring(9);
-        build_image = `${phaseContext.accountConfig.account_id}.dkr.ecr.${phaseContext.accountConfig.region}.amazonaws.com/${image_name_and_tag}`;
+    if (buildImage && buildImage.startsWith('<account>')) {
+        let imageNameAndTag = buildImage.substring(9);
+        buildImage = `${phaseContext.accountConfig.account_id}.dkr.ecr.${phaseContext.accountConfig.region}.amazonaws.com${imageNameAndTag}`;
     }
 
     return createBuildPhaseServiceRole(phaseContext.accountConfig, appName)
@@ -62,11 +62,11 @@ function createBuildPhaseCodeBuildProject(phaseContext) {
                 .then(buildProject => {
                     if (!buildProject) {
                         winston.info(`Creating build phase CodeBuild project ${buildProjectName}`);
-                        return codeBuildCalls.createProject(buildProjectName, appName, build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
+                        return codeBuildCalls.createProject(buildProjectName, appName, buildImage, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
                     }
                     else {
                         winston.info(`Updating build phase CodeBuild project ${buildProjectName}`);
-                        return codeBuildCalls.updateProject(buildProjectName, appName, build_image, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region)
+                        return codeBuildCalls.updateProject(buildProjectName, appName, buildImage, phaseContext.params.environment_variables, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region)
                     }
                 });
         });


### PR DESCRIPTION
The documentation tells users to include the slash between repo
location and repo name, but the code was also doing this. We remove
the code doing this, instead requiring the user to put it in their
image name. It looks better in their handel-codepipeline.yml file
to have the slash included like "<account>/myrepo".