### PR TITLE
Adding npm and PyPi Publishing Phase Types

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,5 +23,7 @@ Handel-CodePipeline is a tool to easily create AWS CodePipelines, including supp
    phase-types/github
    phase-types/handel
    phase-types/handel_delete
+   phase-types/npm
+   phase-types/pypi
    phase-types/runscope
    phase-types/slack_notify

--- a/docs/phase-types/npm.rst
+++ b/docs/phase-types/npm.rst
@@ -1,0 +1,54 @@
+NPM
+======
+The *NPM* phase type configures a pipeline phase to deploy one or more of your application npmjs. 
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - type
+     - string
+     - Yes
+     - npm
+     - This must always be *npm* for the NPM phase type.
+   * - name
+     - string
+     - Yes
+     -
+     - The value you want to show up in the CodePipeline UI as your phase name.
+   * - build_image
+     - string
+     - No
+     - aws/codebuild/nodejs:6.3.1
+     - The code build image needed to deploy project to npm. See here for more info `AWS Codebuild Docs <http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html>`_
+
+Secrets
+-------
+In addition to the parameters specified in your handel-codepipeline.yml file, this phase will prompt you for the following secret information when creating your pipeline:
+
+* NPM Token
+
+For Security reasons these are not saved in your handel-codepipeline.yml file. The NPM token can be found in your .npmrc file see `here <http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules>`_ for more information.
+
+Example Phase Configuration
+---------------------------
+This snippet of a handel-codepipeline.yml file shows the NPM phase being configured:
+
+.. code-block:: yaml
+
+    version: 1
+
+    pipelines:
+      dev:
+        phases:
+        ...
+        - type: npm
+          name: npmDeploy
+        ...

--- a/docs/phase-types/pypi.rst
+++ b/docs/phase-types/pypi.rst
@@ -1,0 +1,61 @@
+Pypi
+======
+The *Pypi* phase type configures a pipeline phase to deploy one or more of your application environments using the Pypi library.
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+   
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - type
+     - string
+     - Yes
+     - pypi
+     - This must always be *pypi* for the Pypi phase type.
+   * - name
+     - string
+     - Yes
+     -
+     - The value you want to show up in the CodePipeline UI as your phase name.
+   * - server
+     - string
+     - No
+     - pypi
+     - The full url for the pypi repo ie: https://test.pypi.org/legacy/
+   * - build_image
+     - string
+     - No
+     - aws/codebuild/python:3.5.2
+     - The code build image needed to deploy project to pypi. See here for more info `AWS Codebuild Docs <http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html>`_
+
+Secrets
+-------
+In addition to the parameters specified in your handel-codepipeline.yml file, this phase will prompt you for the following secret information when creating your pipeline:
+
+* Pypi Username.
+* Pypi Password.
+
+For Security reasons these are not saved in your handel-codepipeline.yml file.
+
+Example Phase Configuration
+---------------------------
+This snippet of a handel-codepipeline.yml file shows the Pypi phase being configured:
+
+.. code-block:: yaml
+
+    version: 1
+
+    pipelines:
+      dev:
+        phases:
+        ...
+        - type: pypi
+          name: pypiDeploy
+          server: https://testpypi.python.org/pypi
+        ...

--- a/lib/aws/ssm-calls.js
+++ b/lib/aws/ssm-calls.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const AWS = require('aws-sdk');
+
+exports.putParameter = function (name, type, value, description) {
+    const ssm = new AWS.SSM({ apiVersion: '2014-11-06' });
+    let param = {
+        Name: name,
+        Type: type,
+        Value: value,
+        Description: description
+    }
+
+    return ssm.putParameter(param).promise();
+}
+
+exports.deleteParameter = function (name) {
+    const ssm = new AWS.SSM({ apiVersion: '2014-11-06' });
+    let param = { Name: name };
+
+    return ssm.deleteParameter(param).promise();
+}
+
+exports.deleteParameters = function (names) {
+    const ssm = new AWS.SSM({ apiVersion: '2014-11-06' });
+    let params = { Names: names };
+
+    return ssm.deleteParameters(params).promise();
+}

--- a/lib/phases/npm/index.js
+++ b/lib/phases/npm/index.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const iamCalls = require('../../aws/iam-calls');
+const ssmCalls = require('../../aws/ssm-calls');
+const codeBuildCalls = require('../../aws/codebuild-calls');
+const util = require('../../common/util');
+const winston = require('winston');
+const inquirer = require('inquirer');
+
+function getNpmProjectName(phaseContext) {
+    return `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`
+}
+
+function getNpmTokenName(appName) {
+    return `${appName}.npmToken`
+}
+
+function createNpmPhaseServiceRole(accountConfig, appName) {
+    let roleName = `${appName}-HandelCodePipelineNPMPhase`
+    return iamCalls.createRoleIfNotExists(roleName, ['codebuild.amazonaws.com'])
+        .then(role => {
+            let policyArn = `arn:aws:iam::${accountConfig.account_id}:policy/handel-codepipeline/${roleName}`;
+            let policyDocParams = {
+                region: accountConfig.region,
+                accountId: accountConfig.account_id,
+                appName: appName
+            }
+            return util.compileHandlebarsTemplate(`${__dirname}/npm-phase-service-policy.json`, policyDocParams)
+                .then(compiledPolicyDoc => {
+                    return iamCalls.createPolicyIfNotExists(roleName, policyArn, JSON.parse(compiledPolicyDoc));
+                });
+        })
+        .then(policy => {
+            return iamCalls.attachPolicyToRole(policy.Arn, roleName);
+        })
+        .then(policyAttachment => {
+            return iamCalls.getRole(roleName);
+        });
+}
+
+function createNpmPhaseCodeBuildProject(phaseContext, accountConfig) {
+    let appName = phaseContext.appName;
+    let npmProjectName = getNpmProjectName(phaseContext)
+    return createNpmPhaseServiceRole(phaseContext.accountConfig, appName)
+        .then(npmPhaseRole => {
+            let npmDeployImage = phaseContext.params.build_image || "aws/codebuild/nodejs:6.3.1";
+            let npmDeployBuildSpec = util.loadFile(`${__dirname}/npm-buildspec.yml`);
+
+            return codeBuildCalls.getProject(npmProjectName)
+                .then(buildProject => {
+                    if (!buildProject) {
+                        winston.info(`Creating NPM deploy phase CodeBuild project ${npmProjectName}`);
+                        return codeBuildCalls.createProject(npmProjectName, appName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec);
+                    }
+                    else {
+                        winston.info(`Updating NPM deploy phase CodeBuild project ${npmProjectName}`);
+                        return codeBuildCalls.updateProject(npmProjectName, appName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec)
+                    }
+                });
+        })
+        .then(() => {
+            let paramName = getNpmTokenName(appName)
+            let paramType = 'SecureString'
+            let paramValue = phaseContext.secrets.npmToken
+            let paramDesc = `NPM token for pipeline: ${phaseContext.pipelineName}`
+            return ssmCalls.putParameter(paramName, paramType, paramValue, paramDesc)
+        });
+}
+
+function getCodePipelinePhaseSpec(phaseContext) {
+    return {
+        name: phaseContext.phaseName,
+        actions: [
+            {
+                inputArtifacts: [
+                    {
+                        name: `Output_Build`
+                    }
+                ],
+                name: phaseContext.phaseName,
+                actionTypeId: {
+                    category: "Test",
+                    owner: "AWS",
+                    version: "1",
+                    provider: "CodeBuild"
+                },
+                configuration: {
+                    ProjectName: getNpmProjectName(phaseContext)
+                },
+                runOrder: 1
+            }
+        ]
+    }
+}
+
+exports.check = function (phaseConfig) {
+    let errors = [];
+    // No required Parameters
+    return errors;
+}
+
+exports.getSecretsForPhase = function() {
+    let questions = [
+        {
+            type: 'input',
+            name: 'npmToken',
+            message: 'Please enter your NPM Token',
+        }
+    ];
+    return inquirer.prompt(questions);
+}
+
+exports.createPhase = function (phaseContext, accountConfig) {
+    return createNpmPhaseCodeBuildProject(phaseContext, accountConfig)
+        .then(() => {
+            return getCodePipelinePhaseSpec(phaseContext);
+        });
+}
+
+exports.deletePhase = function (phaseContext, accountConfig) {
+    let codeBuildProjectName = getNpmProjectName(phaseContext);
+    let appName = phaseContext.appName;
+    winston.info(`Delete CodeBuild project for '${codeBuildProjectName}'`);
+    return codeBuildCalls.deleteProject(codeBuildProjectName)
+        .then(() => {
+            return ssmCalls.deleteParameter(getNpmTokenName(appName));
+        });
+}

--- a/lib/phases/npm/npm-buildspec.yml
+++ b/lib/phases/npm/npm-buildspec.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+    - npm_token=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.npmToken --with-decryption | grep 'Value' | awk '{print $2}' | tr -d '"')
+    - echo '//registry.npmjs.org/:_authToken=${npm_token}' > ~/.npmrc
+  build:
+    commands:
+    - npm publish

--- a/lib/phases/npm/npm-phase-service-policy.json
+++ b/lib/phases/npm/npm-phase-service-policy.json
@@ -1,0 +1,24 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "ssm:GetParameters"
+            ],
+            "Resource": "arn:aws:ssm:{{region}}:{{accountId}}:parameter/{{appName}}*",
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "logs:*",
+                "s3:CreateBucket",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:List*",
+                "s3:PutObject"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}

--- a/lib/phases/pypi/index.js
+++ b/lib/phases/pypi/index.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const iamCalls = require('../../aws/iam-calls');
+const ssmCalls = require('../../aws/ssm-calls');
+const codeBuildCalls = require('../../aws/codebuild-calls');
+const util = require('../../common/util');
+const winston = require('winston');
+const inquirer = require('inquirer');
+
+function getPypiProjectName(phaseContext) {
+    return `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`
+}
+
+function getPypiParameterNames(phaseContext) {
+    return [`${phaseContext.appName}.twine_username`, `${phaseContext.appName}.twine_password`, `${phaseContext.appName}.twine_repo`]
+}
+
+function createPypiParameters(phaseContext) {
+    let params = [
+        {
+            name: `${phaseContext.appName}.twine_username`,
+            type: 'String',
+            value: phaseContext.secrets.pypiUsername,
+            description: `twine user name for pipeline ${phaseContext.appName}`
+        },
+        {
+            name: `${phaseContext.appName}.twine_password`,
+            type: 'SecureString',
+            value: phaseContext.secrets.pypiPassword,
+            description: `twine password for pipeline ${phaseContext.appName}`
+        },
+        {
+            name: `${phaseContext.appName}.twine_repo`,
+            type: 'String',
+            value: phaseContext.params.server || 'pypi',
+            description: `twine repo for pipeline ${phaseContext.appName}`
+        }
+    ];
+
+    let putPromises = [];
+    
+    for (let param of params) {
+        putPromises.push(ssmCalls.putParameter(param.name, param.type, param.value, param.description));
+    }
+
+    return Promise.all(putPromises);
+}
+
+function createPypiPhaseServiceRole(accountConfig, appName) {
+    let roleName = `${appName}-HandelCodePipelinePyPiPhase`;
+    return iamCalls.createRoleIfNotExists(roleName, ['codebuild.amazonaws.com'])
+        .then(role => {
+            let policyArn = `arn:aws:iam::${accountConfig.account_id}:policy/handel-codepipeline/${roleName}`;
+            let policyDocParams = {
+                region: accountConfig.region,
+                accountId: accountConfig.account_id,
+                appName: appName
+            }
+            return util.compileHandlebarsTemplate(`${__dirname}/pypi-phase-service-policy.json`, policyDocParams)
+                .then(compiledPolicyDoc => {
+                    return iamCalls.createPolicyIfNotExists(roleName, policyArn, JSON.parse(compiledPolicyDoc));
+                });
+        })
+        .then(policy => {
+            return iamCalls.attachPolicyToRole(policy.Arn, roleName);
+        })
+        .then(policyAttachment => {
+            return iamCalls.getRole(roleName);
+        });
+}
+
+function createPypiPhaseCodeBuildProject(phaseContext, accountConfig) {
+    let appName = phaseContext.appName;
+    let pypiProjectName = getPypiProjectName(phaseContext)
+    return createPypiPhaseServiceRole(phaseContext.accountConfig, appName)
+        .then(pypiPhaseRole => {
+            let pypiDeployImage = phaseContext.params.build_image || "aws/codebuild/python:3.5.2";
+            let pypiDeployBuildSpec = util.loadFile(`${__dirname}/pypi-buildspec.yml`);
+
+            return codeBuildCalls.getProject(pypiProjectName)
+                .then(buildProject => {
+                    if (!buildProject) {
+                        winston.info(`Creating PyPi deploy phase CodeBuild project ${pypiProjectName}`);
+                        return codeBuildCalls.createProject(pypiProjectName, appName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec);
+                    }
+                    else {
+                        winston.info(`Updating PyPi deploy phase CodeBuild project ${pypiProjectName}`);
+                        return codeBuildCalls.updateProject(pypiProjectName, appName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec)
+                    }
+                });
+        })
+        .then(() => {
+            return createPypiParameters(phaseContext)
+        });
+}
+
+function getCodePipelinePhaseSpec(phaseContext) {
+    return {
+        name: phaseContext.phaseName,
+        actions: [
+            {
+                inputArtifacts: [
+                    {
+                        name: `Output_Build`
+                    }
+                ],
+                name: phaseContext.phaseName,
+                actionTypeId: {
+                    category: "Test",
+                    owner: "AWS",
+                    version: "1",
+                    provider: "CodeBuild"
+                },
+                configuration: {
+                    ProjectName: getPypiProjectName(phaseContext)
+                },
+                runOrder: 1
+            }
+        ]
+    }
+}
+
+exports.check = function (phaseConfig) {
+    let errors = [];
+    // No required Parameters
+    return errors;
+}
+
+exports.getSecretsForPhase = function () {
+    let questions = [
+        {
+            type: 'input',
+            name: 'pypiUsername',
+            message: 'Please enter your PyPi username',
+        },
+        {
+            type: 'input',
+            name: 'pypiPassword',
+            message: 'Please enter your PyPi password',
+        }
+    ];
+    return inquirer.prompt(questions);
+}
+
+exports.createPhase = function (phaseContext, accountConfig) {
+    return createPypiPhaseCodeBuildProject(phaseContext, accountConfig)
+        .then(() => {
+            return getCodePipelinePhaseSpec(phaseContext);
+        });
+}
+
+exports.deletePhase = function (phaseContext, accountConfig) {
+    let codeBuildProjectName = getPypiProjectName(phaseContext);
+    winston.info(`Delete CodeBuild project for '${codeBuildProjectName}'`);
+    return codeBuildCalls.deleteProject(codeBuildProjectName)
+        .then(() => {
+            return ssmCalls.deleteParameters(getPypiParameterNames(phaseContext));
+        });
+}

--- a/lib/phases/pypi/pypi-buildspec.yml
+++ b/lib/phases/pypi/pypi-buildspec.yml
@@ -1,0 +1,16 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+    - pip install twine wheel awscli
+    - pip install -r requirements.txt
+    - rm -rf dist
+    - export TWINE_USERNAME=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_username | grep 'Value' | awk '{print $2}' | tr -d '"')
+    - export TWINE_PASSWORD=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_password --with-decryption | grep 'Value' | awk '{print $2}' | tr -d '"')
+    - export TWINE_REPOSITORY=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_repo | grep 'Value' | awk '{print $2}' | tr -d '"')
+    - if [ "$TWINE_REPOSITORY" != "pypi" ]; then export TWINE_REPOSITORY_URL=$TWINE_REPOSITORY; fi
+  build:
+    commands:
+    - python setup.py sdist bdist_wheel
+    - twine upload dist/*

--- a/lib/phases/pypi/pypi-phase-service-policy.json
+++ b/lib/phases/pypi/pypi-phase-service-policy.json
@@ -1,0 +1,24 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "ssm:GetParameters"
+            ],
+            "Resource": "arn:aws:ssm:{{region}}:{{accountId}}:parameter/{{appName}}*",
+            "Effect": "Allow"
+        },
+        {
+            "Action": [
+                "logs:*",
+                "s3:CreateBucket",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:List*",
+                "s3:PutObject"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "archiver": "^1.3.0",
     "async": "^2.4.0",
-    "aws-sdk": "^2.9.0",
+    "aws-sdk": "^2.94.0",
     "handlebars": "^4.0.8",
     "inquirer": "^3.0.6",
     "js-yaml": "3.7.0",

--- a/test/aws/ssm-calls-test.js
+++ b/test/aws/ssm-calls-test.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const ssmCalls = require('../../lib/aws/ssm-calls');
+const expect = require('chai').expect;
+const AWS = require('aws-sdk-mock');
+const sinon = require('sinon');
+
+describe('ssm calls', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        AWS.restore('SSM');
+    });
+
+    describe('putParameter', function () {
+        it('should create the parameter', function () {
+            let paramName = "FakeParam"
+            let paramType = "String"
+            let paramValue = "FakeValue"
+            let paramDescription = "FakeDescription"
+            AWS.mock('SSM', 'putParameter', Promise.resolve({
+                param: {}
+            }));
+
+            return ssmCalls.putParameter(paramName, paramType, paramValue, paramDescription)
+                .then(param => {
+                    expect(param).to.deep.equal({param: {} });
+                })
+        });
+    });
+
+    //failing for missing region? but functions in full end to end test
+    describe('deleteParameter', function () {
+        it('should create the parameter', function () {
+            let paramName = "FakeParam"
+            AWS.mock('SSM', 'deleteParameter', Promise.resolve({}));
+
+            return ssmCalls.deleteParameter(paramName)
+                .then(param => {
+                    expect(param).to.deep.equal({});
+                })
+        });
+    });
+
+    describe('deleteParameters', function () {
+        it('should delete the parameters', function () {
+            let names = ['FakeParam', 'FakeParam2'];
+            AWS.mock('SSM', 'deleteParameters', Promise.resolve({}));
+
+            return ssmCalls.deleteParameters(names)
+                .then(deletedParams => {
+                    expect(deletedParams).to.deep.equal({})
+                })
+        });
+    });
+});

--- a/test/phases/npm/npm-test.js
+++ b/test/phases/npm/npm-test.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const npm = require('../../../lib/phases/npm');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const iamCalls = require('../../../lib/aws/iam-calls');
+const ssmCalls = require('../../../lib/aws/ssm-calls');
+const codebuildCalls = require('../../../lib/aws/codebuild-calls');
+const inquirer = require('inquirer');
+
+describe('npm phase module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('check', function () {
+        it('should work when all required parameters are provided', function () {
+            let phaseConfig = {};
+            let errors = npm.check(phaseConfig);
+            expect(errors.length).to.equal(0);
+        });
+    });
+
+    describe('getSecretsForPhase', function () {
+        it('should prompt for a npm Username', function () {
+            let token = "FakeUser";
+            let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({ npmToken: token }));
+
+            return npm.getSecretsForPhase()
+                .then(results => {
+                    expect(results.npmToken).to.equal(token);
+                    expect(promptStub.callCount).to.equal(1);
+                });
+        });
+    });
+
+    describe('createPhase', function () {
+        let phaseContext = {
+            appName: 'myApp',
+            accountConfig: {
+                account_id: 111111111111
+            },
+            params: {},
+            secrets: {}
+        }
+
+        let role = {
+            Arn: "FakeArn"
+        }
+
+        it('should create the codebuild project and return the phase config', function () {
+            let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve(role));
+            let createPolicyStub = sandbox.stub(iamCalls, 'createPolicyIfNotExists').returns(Promise.resolve(role));
+            let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
+            let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve(role));
+            let getProjectStub = sandbox.stub(codebuildCalls, 'getProject').returns(Promise.resolve(null));
+            let createProjectStub = sandbox.stub(codebuildCalls, 'createProject').returns(Promise.resolve)
+            let putParameterStub = sandbox.stub(ssmCalls, 'putParameter').returns(Promise.resolve({}));
+
+            return npm.createPhase(phaseContext, {})
+                .then(() => {
+                    expect(createRoleStub.callCount).to.equal(1);
+                    expect(createPolicyStub.callCount).to.equal(1);
+                    expect(attachPolicyStub.callCount).to.equal(1);
+                    expect(getRoleStub.callCount).to.equal(1);
+                    expect(getProjectStub.callCount).to.equal(1);
+                    expect(createProjectStub.callCount).to.equal(1);
+                    expect(putParameterStub.callCount).to.equal(1);
+                });
+        });
+
+        it('should update the project when it already exists', function () {
+            let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve(role));
+            let createPolicyStub = sandbox.stub(iamCalls, 'createPolicyIfNotExists').returns(Promise.resolve(role));
+            let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
+            let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve(role));
+            let getProjectStub = sandbox.stub(codebuildCalls, 'getProject').returns(Promise.resolve({}));
+            let updateProjectStub = sandbox.stub(codebuildCalls, 'updateProject').returns(Promise.resolve);
+            let putParameterStub = sandbox.stub(ssmCalls, 'putParameter').returns(Promise.resolve({}));
+
+            return npm.createPhase(phaseContext, {})
+                .then(() => {
+                    expect(createRoleStub.callCount).to.equal(1);
+                    expect(createPolicyStub.callCount).to.equal(1);
+                    expect(attachPolicyStub.callCount).to.equal(1);
+                    expect(getRoleStub.callCount).to.equal(1);
+                    expect(getProjectStub.callCount).to.equal(1);
+                    expect(updateProjectStub.callCount).to.equal(1);
+                    expect(putParameterStub.callCount).to.equal(1);
+                });
+        })
+    });
+
+    describe('deletePhase', function () {
+        it('should delete the codebuild project', function () {
+            let phaseContext = {
+                phaseName: 'FakePhase',
+                appName: 'FakeApp',
+                params: {
+                    environments_to_deploy: ['dev']
+                }
+            }
+
+            let deleteProjectStub = sandbox.stub(codebuildCalls, 'deleteProject').returns(Promise.resolve(true))
+            let deletePrarameterStub = sandbox.stub(ssmCalls, 'deleteParameter').returns(Promise.resolve(true))
+
+            return npm.deletePhase(phaseContext, {})
+                .then(result => {
+                    expect(result).to.be.true;
+                    expect(deleteProjectStub.callCount).to.equal(1);
+                    expect(deletePrarameterStub.callCount).to.equal(1);
+                });
+        });
+    });
+});

--- a/test/phases/pypi/pypi-test.js
+++ b/test/phases/pypi/pypi-test.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017 Brigham Young University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const pypi = require('../../../lib/phases/pypi');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const iamCalls = require('../../../lib/aws/iam-calls');
+const ssmCalls = require('../../../lib/aws/ssm-calls');
+const codebuildCalls = require('../../../lib/aws/codebuild-calls');
+const inquirer = require('inquirer');
+
+describe('pypi phase module', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('check', function () {
+        it('should work when all required parameters are provided', function () {
+            let phaseConfig = {
+                server: "FakeServer"
+            };
+            let errors = pypi.check(phaseConfig);
+            expect(errors.length).to.equal(0);
+        });
+    });
+
+    describe('getSecretsForPhase', function () {
+        it('should prompt for a pypi Username', function () {
+            let user = "FakeUser";
+            let password = "FakePassword";
+            let promptStub = sandbox.stub(inquirer, 'prompt').returns(Promise.resolve({ pypiUsername: user, pypiPassword: password }));
+
+            return pypi.getSecretsForPhase()
+                .then(results => {
+                    expect(results.pypiUsername).to.equal(user);
+                    expect(results.pypiPassword).to.equal(password);
+                    expect(promptStub.callCount).to.equal(1);
+                });
+        });
+    });
+
+    describe('createPhase', function () {
+        let phaseContext = {
+            appName: 'myApp',
+            accountConfig: {
+                account_id: 111111111111
+            },
+            params: {},
+            secrets: {}
+        }
+
+        let role = {
+            Arn: "FakeArn"
+        }
+
+        it('should create the codebuild project and return the phase config', function () {
+            let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve(role));
+            let createPolicyStub = sandbox.stub(iamCalls, 'createPolicyIfNotExists').returns(Promise.resolve(role));
+            let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
+            let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve(role));
+            let getProjectStub = sandbox.stub(codebuildCalls, 'getProject').returns(Promise.resolve(null));
+            let createProjectStub = sandbox.stub(codebuildCalls, 'createProject').returns(Promise.resolve);
+            let putParameterStub = sandbox.stub(ssmCalls, 'putParameter').returns(Promise.resolve({}));
+
+            return pypi.createPhase(phaseContext, {})
+                .then(() => {
+                    expect(createRoleStub.callCount).to.equal(1);
+                    expect(createPolicyStub.callCount).to.equal(1);
+                    expect(attachPolicyStub.callCount).to.equal(1);
+                    expect(getRoleStub.callCount).to.equal(1);
+                    expect(getProjectStub.callCount).to.equal(1);
+                    expect(createProjectStub.callCount).to.equal(1);
+                    expect(putParameterStub.callCount).to.equal(3);
+                });
+        });
+
+        it('should update the project when it already exists', function () {
+            let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve(role));
+            let createPolicyStub = sandbox.stub(iamCalls, 'createPolicyIfNotExists').returns(Promise.resolve(role));
+            let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
+            let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve(role));
+            let getProjectStub = sandbox.stub(codebuildCalls, 'getProject').returns(Promise.resolve({}));
+            let updateProjectStub = sandbox.stub(codebuildCalls, 'updateProject').returns(Promise.resolve);
+            let putParameterStub = sandbox.stub(ssmCalls, 'putParameter').returns(Promise.resolve({}));
+
+            return pypi.createPhase(phaseContext, {})
+                .then(() => {
+                    expect(createRoleStub.callCount).to.equal(1);
+                    expect(createPolicyStub.callCount).to.equal(1);
+                    expect(attachPolicyStub.callCount).to.equal(1);
+                    expect(getRoleStub.callCount).to.equal(1);
+                    expect(getProjectStub.callCount).to.equal(1);
+                    expect(updateProjectStub.callCount).to.equal(1);
+                    expect(putParameterStub.callCount).to.equal(3)
+                });
+        })
+    });
+
+    describe('deletePhase', function () {
+        it('should delete the codebuild project', function () {
+            let phaseContext = {
+                phaseName: 'FakePhase',
+                appName: 'FakeApp',
+                params: {}
+            }
+
+            let deleteProjectStub = sandbox.stub(codebuildCalls, 'deleteProject').returns(Promise.resolve(true))
+            let deleteParametersStub = sandbox.stub(ssmCalls, 'deleteParameters').returns(Promise.resolve(true))
+            return pypi.deletePhase(phaseContext, {})
+                .then(result => {
+                    expect(result).to.be.true;
+                    expect(deleteProjectStub.callCount).to.equal(1);
+                    expect(deleteParametersStub.callCount).to.equal(1);
+                });
+        });
+    });
+}); 


### PR DESCRIPTION
Here is a first pass that adds functioning phases to publish to pypi (or other custom python repository server) and to NPM.

Note it is super basic in functionality and assumes all the versioning steps have been taken care of prior to publish. IE both npm and pypi phase will fail if you fail to increment your versions.

Let me know what you think. I'm sure there is a lot that can be refactored.

resolves #64 