### PR TITLE
Added err message to lambda output

### DIFF
--- a/lib/phases/runscope/runscope-code/runscope.py
+++ b/lib/phases/runscope/runscope-code/runscope.py
@@ -113,8 +113,9 @@ def run_tests(event, context):
                 'type': 'JobFailed',
                 'message': 'One or more tests failed'
             })
-    except:
+    except Exception as e:
+        print(e)
         code_pipeline.put_job_failure_result(jobId=jobId, failureDetails={
             'type': 'JobFailed',
-            'message': 'Unhandled exception during Runscope tests execution'
+            'message': 'Unhandled exception during Runscope tests execution: ' + e.message
         })


### PR DESCRIPTION
Occasionally, the HandelCodePipelineRunscopeLambda would report a failure to AWS CodePipeline because Runscope threw an non-critical exception that wasn't handled properly by the lambda. The new logging and added error output will help for future development and to address the current problem with Runscope tests passing but AWS CodePipeline reporting that one or more tests failed.