### PR TITLE
Add HANDEL_PIPELINE_NAME and HANDEL_PHASE_NAME to CodeBuild

### DIFF
--- a/lib/aws/codebuild-calls.js
+++ b/lib/aws/codebuild-calls.js
@@ -51,7 +51,7 @@ function createProject(codeBuild, createParams) {
     return deferred.promise;
 }
 
-function getProjectParams(projectName, appName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec) {
+function getProjectParams(projectName, appName, pipelineName, phaseName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec) {
     let projectParams = {
         name: projectName,
         description: projectName,
@@ -90,7 +90,9 @@ function getProjectParams(projectName, appName, imageName, environmentVariables,
     //Inject pre-provided environment variables
     projectParams.environment.environmentVariables.push(getCodeBuildEnvVarDef("AWS_ACCOUNT_ID", accountId.toString()));
     projectParams.environment.environmentVariables.push(getCodeBuildEnvVarDef("AWS_REGION", region));
-    projectParams.environment.environmentVariables.push(getCodeBuildEnvVarDef("HANDEL_PIPELINE_NAME", appName));
+    projectParams.environment.environmentVariables.push(getCodeBuildEnvVarDef("HANDEL_APP_NAME", appName));
+    projectParams.environment.environmentVariables.push(getCodeBuildEnvVarDef("HANDEL_PIPELINE_NAME", pipelineName));
+    projectParams.environment.environmentVariables.push(getCodeBuildEnvVarDef("HANDEL_PHASE_NAME", phaseName));
 
     //Add environment variables for codebuild project
     for (let envKey in environmentVariables) {
@@ -100,9 +102,9 @@ function getProjectParams(projectName, appName, imageName, environmentVariables,
     return projectParams
 }
 
-exports.createProject = function (projectName, appName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec) {
+exports.createProject = function (projectName, appName, pipelineName, phaseName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec) {
     const codeBuild = new AWS.CodeBuild({ apiVersion: '2016-10-06' });
-    let projectParams = getProjectParams(projectName, appName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec);
+    let projectParams = getProjectParams(projectName, appName, pipelineName, phaseName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec);
 
     return createProject(codeBuild, projectParams)
         .then(createResponse => {
@@ -110,9 +112,9 @@ exports.createProject = function (projectName, appName, imageName, environmentVa
         });
 }
 
-exports.updateProject = function (projectName, appName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec) {
+exports.updateProject = function (projectName, appName, pipelineName, phaseName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec) {
     const codeBuild = new AWS.CodeBuild({ apiVersion: '2016-10-06' });
-    let projectParams = getProjectParams(projectName, appName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec);
+    let projectParams = getProjectParams(projectName, appName, pipelineName, phaseName, imageName, environmentVariables, accountId, serviceRoleArn, region, buildSpec);
 
     return codeBuild.updateProject(projectParams).promise()
         .then(updateResponse => {

--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -52,7 +52,7 @@ function createBuildPhaseServiceRole(accountConfig, appName, extraPolicies) {
 }
 
 function createBuildPhaseCodeBuildProject(phaseContext, extras) {
-    let appName = phaseContext.appName;
+    let {appName, pipelineName, phaseName} = phaseContext;
     let buildProjectName = getBuildProjectName(phaseContext);
     let buildImage = phaseContext.params.build_image;
 
@@ -69,11 +69,11 @@ function createBuildPhaseCodeBuildProject(phaseContext, extras) {
                 .then(buildProject => {
                     if (!buildProject) {
                         winston.info(`Creating build phase CodeBuild project ${buildProjectName}`);
-                        return codeBuildCalls.createProject(buildProjectName, appName, buildImage, envVars, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
+                        return codeBuildCalls.createProject(buildProjectName, appName, pipelineName, phaseName, buildImage, envVars, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
                     }
                     else {
                         winston.info(`Updating build phase CodeBuild project ${buildProjectName}`);
-                        return codeBuildCalls.updateProject(buildProjectName, appName, buildImage, envVars, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region)
+                        return codeBuildCalls.updateProject(buildProjectName, appName, pipelineName, phaseName, buildImage, envVars, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
                     }
                 });
         });

--- a/lib/phases/handel/index.js
+++ b/lib/phases/handel/index.js
@@ -40,7 +40,7 @@ function createDeployPhaseServiceRole(accountId) {
 }
 
 function createDeployPhaseCodeBuildProject(phaseContext, accountConfig) {
-    let appName = phaseContext.appName;
+    let {appName, pipelineName, phaseName} = phaseContext;
     let deployProjectName = getDeployProjectName(phaseContext)
     return createDeployPhaseServiceRole(phaseContext.accountConfig.account_id)
         .then(deployPhaseRole => {
@@ -55,11 +55,11 @@ function createDeployPhaseCodeBuildProject(phaseContext, accountConfig) {
                 .then(buildProject => {
                     if (!buildProject) {
                         winston.info(`Creating Handel deploy phase CodeBuild project ${deployProjectName}`);
-                        return codeBuildCalls.createProject(deployProjectName, appName, handelDeployImage, handelDeployEnvVars, phaseContext.accountConfig.account_id, deployPhaseRole.Arn, phaseContext.accountConfig.region, handelDeployBuildSpec);
+                        return codeBuildCalls.createProject(deployProjectName, appName, pipelineName, phaseName, handelDeployImage, handelDeployEnvVars, phaseContext.accountConfig.account_id, deployPhaseRole.Arn, phaseContext.accountConfig.region, handelDeployBuildSpec);
                     }
                     else {
                         winston.info(`Updating Handel deploy phase CodeBuild project ${deployProjectName}`);
-                        return codeBuildCalls.updateProject(deployProjectName, appName, handelDeployImage, handelDeployEnvVars, phaseContext.accountConfig.account_id, deployPhaseRole.Arn, phaseContext.accountConfig.region, handelDeployBuildSpec)
+                        return codeBuildCalls.updateProject(deployProjectName, appName, pipelineName, phaseName, handelDeployImage, handelDeployEnvVars, phaseContext.accountConfig.account_id, deployPhaseRole.Arn, phaseContext.accountConfig.region, handelDeployBuildSpec)
                     }
                 });
         });

--- a/lib/phases/handel_delete/index.js
+++ b/lib/phases/handel_delete/index.js
@@ -40,7 +40,7 @@ function createDeletePhaseServiceRole(accountId) {
 }
 
 function createDeletePhaseCodeBuildProject(phaseContext, accountConfig) {
-    let appName = phaseContext.appName;
+    let {appName, pipelineName, phaseName} = phaseContext;
     let deleteProjectName = getDeleteProjectName(phaseContext)
     return createDeletePhaseServiceRole(phaseContext.accountConfig.account_id)
         .then(deletePhaseRole => {
@@ -55,11 +55,11 @@ function createDeletePhaseCodeBuildProject(phaseContext, accountConfig) {
                 .then(buildProject => {
                     if (!buildProject) {
                         winston.info(`Creating Handel delete phase CodeBuild project ${deleteProjectName}`);
-                        return codeBuildCalls.createProject(deleteProjectName, appName, handelDeleteImage, handelDeleteEnvVars, phaseContext.accountConfig.account_id, deletePhaseRole.Arn, phaseContext.accountConfig.region, handelDeleteBuildSpec);
+                        return codeBuildCalls.createProject(deleteProjectName, appName, pipelineName, phaseName, handelDeleteImage, handelDeleteEnvVars, phaseContext.accountConfig.account_id, deletePhaseRole.Arn, phaseContext.accountConfig.region, handelDeleteBuildSpec);
                     }
                     else {
                         winston.info(`Updating Handel delete phase CodeBuild project ${deleteProjectName}`);
-                        return codeBuildCalls.updateProject(deleteProjectName, appName, handelDeleteImage, handelDeleteEnvVars, phaseContext.accountConfig.account_id, deletePhaseRole.Arn, phaseContext.accountConfig.region, handelDeleteBuildSpec)
+                        return codeBuildCalls.updateProject(deleteProjectName, appName, pipelineName, phaseName, handelDeleteImage, handelDeleteEnvVars, phaseContext.accountConfig.account_id, deletePhaseRole.Arn, phaseContext.accountConfig.region, handelDeleteBuildSpec)
                     }
                 });
         });

--- a/lib/phases/npm/index.js
+++ b/lib/phases/npm/index.js
@@ -53,7 +53,7 @@ function createNpmPhaseServiceRole(accountConfig, appName) {
 }
 
 function createNpmPhaseCodeBuildProject(phaseContext, accountConfig) {
-    let appName = phaseContext.appName;
+    let {appName, pipelineName, phaseName} = phaseContext;
     let npmProjectName = getNpmProjectName(phaseContext)
     return createNpmPhaseServiceRole(phaseContext.accountConfig, appName)
         .then(npmPhaseRole => {
@@ -64,11 +64,11 @@ function createNpmPhaseCodeBuildProject(phaseContext, accountConfig) {
                 .then(buildProject => {
                     if (!buildProject) {
                         winston.info(`Creating NPM deploy phase CodeBuild project ${npmProjectName}`);
-                        return codeBuildCalls.createProject(npmProjectName, appName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec);
+                        return codeBuildCalls.createProject(npmProjectName, appName, pipelineName, phaseName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec);
                     }
                     else {
                         winston.info(`Updating NPM deploy phase CodeBuild project ${npmProjectName}`);
-                        return codeBuildCalls.updateProject(npmProjectName, appName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec)
+                        return codeBuildCalls.updateProject(npmProjectName, appName, pipelineName, phaseName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec)
                     }
                 });
         })

--- a/lib/phases/pypi/index.js
+++ b/lib/phases/pypi/index.js
@@ -84,7 +84,7 @@ function createPypiPhaseServiceRole(accountConfig, appName) {
 }
 
 function createPypiPhaseCodeBuildProject(phaseContext, accountConfig) {
-    let appName = phaseContext.appName;
+    let {appName, pipelineName, phaseName} = phaseContext;
     let pypiProjectName = getPypiProjectName(phaseContext)
     return createPypiPhaseServiceRole(phaseContext.accountConfig, appName)
         .then(pypiPhaseRole => {
@@ -95,11 +95,11 @@ function createPypiPhaseCodeBuildProject(phaseContext, accountConfig) {
                 .then(buildProject => {
                     if (!buildProject) {
                         winston.info(`Creating PyPi deploy phase CodeBuild project ${pypiProjectName}`);
-                        return codeBuildCalls.createProject(pypiProjectName, appName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec);
+                        return codeBuildCalls.createProject(pypiProjectName, appName, pipelineName, phaseName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec);
                     }
                     else {
                         winston.info(`Updating PyPi deploy phase CodeBuild project ${pypiProjectName}`);
-                        return codeBuildCalls.updateProject(pypiProjectName, appName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec)
+                        return codeBuildCalls.updateProject(pypiProjectName, appName, pipelineName, phaseName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec)
                     }
                 });
         })

--- a/test/aws/codebuild-calls-test.js
+++ b/test/aws/codebuild-calls-test.js
@@ -41,7 +41,7 @@ describe('codebuild calls module', function () {
                 }
             }));
 
-            return codeBuildCalls.createProject(projectName, projectName, "FakeImage", { SOME_KEY: "some_value" }, "777777777777", "FakeArn", "us-west-2")
+            return codeBuildCalls.createProject(projectName, projectName, 'pipeline', 'phase', "FakeImage", { SOME_KEY: "some_value" }, "777777777777", "FakeArn", "us-west-2")
                 .then(project => {
                     expect(project.Name).to.equal(projectName);
                 });
@@ -58,7 +58,7 @@ describe('codebuild calls module', function () {
                 }
             }));
 
-            return codeBuildCalls.updateProject(projectName, projectName, "FakeImage", {}, "777777777777", "FakeArn", "us-west-2")
+            return codeBuildCalls.updateProject(projectName, projectName, 'pipeline', 'phase', "FakeImage", {}, "777777777777", "FakeArn", "us-west-2")
                 .then(project => {
                     expect(project.Name).to.equal(projectName);
                 })

--- a/test/phases/codebuild/codebuild-test.js
+++ b/test/phases/codebuild/codebuild-test.js
@@ -219,6 +219,8 @@ describe('codebuild phase module', function () {
                         expect(createProjectStub).to.have.been.calledWithMatch(
                             sinon.match('myApp-pipeline-phase'),
                             sinon.match('myApp'),
+                            sinon.match(phaseContext.pipelineName),
+                            sinon.match(phaseContext.phaseName),
                             sinon.match('FakeImage'),
                             sinon.match(envVars),
                             sinon.match.any,


### PR DESCRIPTION
Also makes HANDEL_APP_NAME reflect the app name, not the pipeline name.  This gives us all the info we need to deconstruct an injected `extra_resource` env var name.