### PR TITLE
Remove version from Handel deploy and update CodeBuild image.

### DIFF
--- a/lib/phases/handel/deploy-buildspec.yml
+++ b/lib/phases/handel/deploy-buildspec.yml
@@ -6,4 +6,4 @@ phases:
     - npm install -g handel
   build:
     commands:
-    - handel deploy -e $ENVS_TO_DEPLOY -c $HANDEL_ACCOUNT_CONFIG -v $CODEBUILD_SOURCE_VERSION
+    - handel deploy -e $ENVS_TO_DEPLOY -c $HANDEL_ACCOUNT_CONFIG

--- a/lib/phases/handel/index.js
+++ b/lib/phases/handel/index.js
@@ -48,7 +48,7 @@ function createDeployPhaseCodeBuildProject(phaseContext, accountConfig) {
                 ENVS_TO_DEPLOY: phaseContext.params.environments_to_deploy.join(","),
                 HANDEL_ACCOUNT_CONFIG: new Buffer(JSON.stringify(accountConfig)).toString("base64")
             }
-            let handelDeployImage = "aws/codebuild/nodejs:6.3.1";
+            let handelDeployImage = "aws/codebuild/nodejs:7.0.0";
             let handelDeployBuildSpec = util.loadFile(`${__dirname}/deploy-buildspec.yml`);
 
             return codeBuildCalls.getProject(deployProjectName)


### PR DESCRIPTION
Handel removed the '-v' flag, so we won't include it when creating
pipelines anymore.

Updated the CodeBuild image to use Node 7.x, which is the latest
currently provided by AWS.

Resolves #80 
Resolves #81 