### PR TITLE
Add support for setting a custom build role on Codebuild phases

### DIFF
--- a/docs/phase-types/codebuild.rst
+++ b/docs/phase-types/codebuild.rst
@@ -37,6 +37,11 @@ Parameters
      - No
      - {}
      - A set of key/value pairs that will be injected into the running CodeBuild jobs.
+   * - build_role
+     - string
+     - No
+     - Handel-created role
+     - The role that will be assigned to the CodeBuild project. This role must already exist in your account and must be assumable by CodeBuild.
    * - extra_resources
      - :ref:`codebuild-extras`
      - No
@@ -80,6 +85,10 @@ The following services are currently supported in `extra_resources`:
 * `DynamoDB <https://handel.readthedocs.io/en/latest/supported-services/dynamodb.html>`_
 * `S3 <https://handel.readthedocs.io/en/latest/supported-services/s3.html>`_
 
+.. NOTE::
+
+  If you use `extra_resources` together with a custom `build_role`, you are responsible for making sure that your custom build role allows access to the extra resources that are created.
+
 Environment Variable Prefix
 ***************************
 
@@ -110,7 +119,7 @@ This snippet of a handel-codepipeline.yml file shows the CodeBuild phase being c
             MY_CUSTOM_ENV: my_custom_value
         ...
 
-This is a snippet of a handel-codepipeline.yml file which includes an S3 bucket as an extra resource:
+This is a snippet of a handel-codepipeline.yml file which includes an S3 bucket as an extra resource and a custom IAM role:
 
 .. code-block:: yaml
 
@@ -125,6 +134,7 @@ This is a snippet of a handel-codepipeline.yml file which includes an S3 bucket 
           build_image: aws/codebuild/docker:1.12.1
           environment_Variables:
             MY_CUSTOM_ENV: my_custom_value
+          build_role: my-custom-codebuild-role
           extra_resources:
             cache_bucket:
               type: s3

--- a/lib/phases/codebuild/index.js
+++ b/lib/phases/codebuild/index.js
@@ -63,7 +63,15 @@ function createBuildPhaseCodeBuildProject(phaseContext, extras) {
 
     let envVars = Object.assign({}, phaseContext.params.environment_variables, extras.environmentVariables);
 
-    return createBuildPhaseServiceRole(phaseContext.accountConfig, appName, extras.policies)
+    let buildPhaseRole;
+
+    if (phaseContext.params.build_role) {
+        buildPhaseRole = lookupRole(phaseContext.params.build_role);
+    } else {
+        buildPhaseRole = createBuildPhaseServiceRole(phaseContext.accountConfig, appName, extras.policies);
+    }
+
+    return buildPhaseRole
         .then(buildPhaseRole => {
             return codeBuildCalls.getProject(buildProjectName)
                 .then(buildProject => {
@@ -76,6 +84,16 @@ function createBuildPhaseCodeBuildProject(phaseContext, extras) {
                         return codeBuildCalls.updateProject(buildProjectName, appName, pipelineName, phaseName, buildImage, envVars, phaseContext.accountConfig.account_id, buildPhaseRole.Arn, phaseContext.accountConfig.region);
                     }
                 });
+        });
+}
+
+function lookupRole(roleName) {
+    return iamCalls.getRole(roleName)
+        .then(result => {
+            if (!result) {
+                throw new Error(`No role named ${roleName} exists in this account`);
+            }
+            return result;
         });
 }
 


### PR DESCRIPTION
This adds a `build_role` property to codebuild phases.  This allows the user to customize the permissions granted to their codebuild project.

## Caveats:

Right now, if the user combines `build_role` with `extra_resources`, they are responsible for making sure that the build role grants access to the created resources.  We could modify this to attach a policy to the existing role which grants that access, but I'm loathe to modify people's roles.  However, it is a fairly low-risk modification, as we grant a small number of privileges on a specific ARN.  What do you think?