### PR TITLE
fixing a bug from the addition of 'version' to aws parameter store

### DIFF
--- a/lib/phases/pypi/pypi-buildspec.yml
+++ b/lib/phases/pypi/pypi-buildspec.yml
@@ -6,9 +6,9 @@ phases:
     - pip install twine wheel awscli
     - pip install -r requirements.txt
     - rm -rf dist
-    - export TWINE_USERNAME=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_username | grep 'Value' | awk '{print $2}' | tr -d '"')
-    - export TWINE_PASSWORD=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_password --with-decryption | grep 'Value' | awk '{print $2}' | tr -d '"')
-    - export TWINE_REPOSITORY=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_repo | grep 'Value' | awk '{print $2}' | tr -d '"')
+    - export TWINE_USERNAME=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_username | grep 'Value' | awk '{print $2}' | tr -d '",')
+    - export TWINE_PASSWORD=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_password --with-decryption | grep 'Value' | awk '{print $2}' | tr -d '",')
+    - export TWINE_REPOSITORY=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_repo | grep 'Value' | awk '{print $2}' | tr -d '",')
     - if [ "$TWINE_REPOSITORY" != "pypi" ]; then export TWINE_REPOSITORY_URL=$TWINE_REPOSITORY; fi
   build:
     commands:


### PR DESCRIPTION
This is kind of a dirty fix

We should rewrite the buildspec to be handelbars template and pull the environment variables from parameter store via the buildspec instead of by commands in the buildspec

Resolves #84 