### PR TITLE
refactored pypi and npm to use builtin parameter store features

### DIFF
--- a/lib/phases/npm/index.js
+++ b/lib/phases/npm/index.js
@@ -25,8 +25,8 @@ function getNpmProjectName(phaseContext) {
     return `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`
 }
 
-function getNpmTokenName(appName) {
-    return `${appName}.npmToken`
+function getNpmTokenName(phaseContext) {
+    return `${phaseContext.appName}.${phaseContext.pipelineName}.npmToken`
 }
 
 function createNpmPhaseServiceRole(accountConfig, appName) {
@@ -58,22 +58,24 @@ function createNpmPhaseCodeBuildProject(phaseContext, accountConfig) {
     return createNpmPhaseServiceRole(phaseContext.accountConfig, appName)
         .then(npmPhaseRole => {
             let npmDeployImage = phaseContext.params.build_image || "aws/codebuild/nodejs:6.3.1";
-            let npmDeployBuildSpec = util.loadFile(`${__dirname}/npm-buildspec.yml`);
-
-            return codeBuildCalls.getProject(npmProjectName)
-                .then(buildProject => {
-                    if (!buildProject) {
-                        winston.info(`Creating NPM deploy phase CodeBuild project ${npmProjectName}`);
-                        return codeBuildCalls.createProject(npmProjectName, appName, pipelineName, phaseName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec);
-                    }
-                    else {
-                        winston.info(`Updating NPM deploy phase CodeBuild project ${npmProjectName}`);
-                        return codeBuildCalls.updateProject(npmProjectName, appName, pipelineName, phaseName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec)
-                    }
-                });
+            let buildspecParams = {"pipeline_name": `${appName}.${pipelineName}`};
+            return util.compileHandlebarsTemplate(`${__dirname}/npm-buildspec.yml`, buildspecParams)
+                .then(npmDeployBuildSpec => {
+                    return codeBuildCalls.getProject(npmProjectName)
+                        .then(buildProject => {
+                            if (!buildProject) {
+                                winston.info(`Creating NPM deploy phase CodeBuild project ${npmProjectName}`);
+                                return codeBuildCalls.createProject(npmProjectName, appName, pipelineName, phaseName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec);
+                            }
+                            else {
+                                winston.info(`Updating NPM deploy phase CodeBuild project ${npmProjectName}`);
+                                return codeBuildCalls.updateProject(npmProjectName, appName, pipelineName, phaseName, npmDeployImage, {}, phaseContext.accountConfig.account_id, npmPhaseRole.Arn, phaseContext.accountConfig.region, npmDeployBuildSpec)
+                            }
+                        });
+                })
         })
         .then(() => {
-            let paramName = getNpmTokenName(appName)
+            let paramName = getNpmTokenName(phaseContext)
             let paramType = 'SecureString'
             let paramValue = phaseContext.secrets.npmToken
             let paramDesc = `NPM token for pipeline: ${phaseContext.pipelineName}`
@@ -133,10 +135,9 @@ exports.deployPhase = function (phaseContext, accountConfig) {
 
 exports.deletePhase = function (phaseContext, accountConfig) {
     let codeBuildProjectName = getNpmProjectName(phaseContext);
-    let appName = phaseContext.appName;
     winston.info(`Delete CodeBuild project for '${codeBuildProjectName}'`);
     return codeBuildCalls.deleteProject(codeBuildProjectName)
         .then(() => {
-            return ssmCalls.deleteParameter(getNpmTokenName(appName));
+            return ssmCalls.deleteParameter(getNpmTokenName(phaseContext));
         });
 }

--- a/lib/phases/npm/index.js
+++ b/lib/phases/npm/index.js
@@ -25,8 +25,13 @@ function getNpmProjectName(phaseContext) {
     return `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`
 }
 
+function getNpmParameterPrefix(phaseContext) {
+    return `${phaseContext.appName}.${phaseContext.pipelineName}`
+}
+
 function getNpmTokenName(phaseContext) {
-    return `${phaseContext.appName}.${phaseContext.pipelineName}.npmToken`
+    let prefix = getNpmParameterPrefix(phaseContext)
+    return `${prefix}.npmToken`
 }
 
 function createNpmPhaseServiceRole(accountConfig, appName) {
@@ -58,7 +63,7 @@ function createNpmPhaseCodeBuildProject(phaseContext, accountConfig) {
     return createNpmPhaseServiceRole(phaseContext.accountConfig, appName)
         .then(npmPhaseRole => {
             let npmDeployImage = phaseContext.params.build_image || "aws/codebuild/nodejs:6.3.1";
-            let buildspecParams = {"pipeline_name": `${appName}.${pipelineName}`};
+            let buildspecParams = {"parameter_prefix": `${appName}.${pipelineName}`};
             return util.compileHandlebarsTemplate(`${__dirname}/npm-buildspec.yml`, buildspecParams)
                 .then(npmDeployBuildSpec => {
                     return codeBuildCalls.getProject(npmProjectName)
@@ -78,7 +83,7 @@ function createNpmPhaseCodeBuildProject(phaseContext, accountConfig) {
             let paramName = getNpmTokenName(phaseContext)
             let paramType = 'SecureString'
             let paramValue = phaseContext.secrets.npmToken
-            let paramDesc = `NPM token for pipeline: ${phaseContext.pipelineName}`
+            let paramDesc = `NPM token for pipeline`
             return ssmCalls.putParameter(paramName, paramType, paramValue, paramDesc)
         });
 }

--- a/lib/phases/npm/npm-buildspec.yml
+++ b/lib/phases/npm/npm-buildspec.yml
@@ -1,10 +1,13 @@
 version: 0.2
 
+env:
+  parameter-store:
+    NPM_TOKEN: {{pipeline_name}}.npmToken
+
 phases:
   pre_build:
     commands:
-    - npm_token=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.npmToken --with-decryption | grep 'Value' | awk '{print $2}' | tr -d '"')
-    - echo '//registry.npmjs.org/:_authToken=${npm_token}' > ~/.npmrc
+    - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
   build:
     commands:
     - npm publish

--- a/lib/phases/npm/npm-buildspec.yml
+++ b/lib/phases/npm/npm-buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   parameter-store:
-    NPM_TOKEN: {{pipeline_name}}.npmToken
+    NPM_TOKEN: {{parameter_prefix}}.npmToken
 
 phases:
   pre_build:

--- a/lib/phases/pypi/index.js
+++ b/lib/phases/pypi/index.js
@@ -25,29 +25,35 @@ function getPypiProjectName(phaseContext) {
     return `${phaseContext.appName}-${phaseContext.pipelineName}-${phaseContext.phaseName}`
 }
 
+function getPypiParameterPrefix(phaseContext){
+    return `${phaseContext.appName}.${phaseContext.pipelineName}`
+}
+
 function getPypiParameterNames(phaseContext) {
-    return [`${phaseContext.appName}.${phaseContext.pipelineName}.twine_username`, `${phaseContext.appName}.${phaseContext.pipelineName}.twine_password`, `${phaseContext.appName}.${phaseContext.pipelineName}.twine_repo`]
+    let prefix = getPypiParameterPrefix(phaseContext);
+    return [`${prefix}.twine_username`, `${prefix}.twine_password`, `${prefix}.twine_repo`]
 }
 
 function createPypiParameters(phaseContext) {
+    let prefix = getPypiParameterPrefix(phaseContext);
     let params = [
         {
-            name: `${phaseContext.appName}.${phaseContext.pipelineName}.twine_username`,
+            name: `${prefix}.twine_username`,
             type: 'String',
             value: phaseContext.secrets.pypiUsername,
-            description: `twine user name for pipeline ${phaseContext.appName}.${phaseContext.pipelineName}`
+            description: `twine user name for pipeline ${prefix}`
         },
         {
-            name: `${phaseContext.appName}.${phaseContext.pipelineName}.twine_password`,
+            name: `${prefix}.twine_password`,
             type: 'SecureString',
             value: phaseContext.secrets.pypiPassword,
-            description: `twine password for pipeline ${phaseContext.appName}.${phaseContext.pipelineName}`
+            description: `twine password for pipeline ${prefix}`
         },
         {
-            name: `${phaseContext.appName}.${phaseContext.pipelineName}.twine_repo`,
+            name: `${prefix}.twine_repo`,
             type: 'String',
             value: phaseContext.params.server || 'pypi',
-            description: `twine repo for pipeline ${phaseContext.appName}.${phaseContext.pipelineName}`
+            description: `twine repo for pipeline ${prefix}`
         }
     ];
 
@@ -87,7 +93,7 @@ function createPypiPhaseCodeBuildProject(phaseContext, accountConfig) {
     let {appName, pipelineName, phaseName} = phaseContext;
     let pypiProjectName = getPypiProjectName(phaseContext);
     let buildspecParams = {
-        "pipeline_name": `${appName}.${pipelineName}`,
+        "parameter_prefix": `${appName}.${pipelineName}`,
         "twine_repo_url": phaseContext.params.server
     }
     return createPypiPhaseServiceRole(phaseContext.accountConfig, appName)

--- a/lib/phases/pypi/index.js
+++ b/lib/phases/pypi/index.js
@@ -26,28 +26,28 @@ function getPypiProjectName(phaseContext) {
 }
 
 function getPypiParameterNames(phaseContext) {
-    return [`${phaseContext.appName}.twine_username`, `${phaseContext.appName}.twine_password`, `${phaseContext.appName}.twine_repo`]
+    return [`${phaseContext.appName}.${phaseContext.pipelineName}.twine_username`, `${phaseContext.appName}.${phaseContext.pipelineName}.twine_password`, `${phaseContext.appName}.${phaseContext.pipelineName}.twine_repo`]
 }
 
 function createPypiParameters(phaseContext) {
     let params = [
         {
-            name: `${phaseContext.appName}.twine_username`,
+            name: `${phaseContext.appName}.${phaseContext.pipelineName}.twine_username`,
             type: 'String',
             value: phaseContext.secrets.pypiUsername,
-            description: `twine user name for pipeline ${phaseContext.appName}`
+            description: `twine user name for pipeline ${phaseContext.appName}.${phaseContext.pipelineName}`
         },
         {
-            name: `${phaseContext.appName}.twine_password`,
+            name: `${phaseContext.appName}.${phaseContext.pipelineName}.twine_password`,
             type: 'SecureString',
             value: phaseContext.secrets.pypiPassword,
-            description: `twine password for pipeline ${phaseContext.appName}`
+            description: `twine password for pipeline ${phaseContext.appName}.${phaseContext.pipelineName}`
         },
         {
-            name: `${phaseContext.appName}.twine_repo`,
+            name: `${phaseContext.appName}.${phaseContext.pipelineName}.twine_repo`,
             type: 'String',
             value: phaseContext.params.server || 'pypi',
-            description: `twine repo for pipeline ${phaseContext.appName}`
+            description: `twine repo for pipeline ${phaseContext.appName}.${phaseContext.pipelineName}`
         }
     ];
 
@@ -85,22 +85,27 @@ function createPypiPhaseServiceRole(accountConfig, appName) {
 
 function createPypiPhaseCodeBuildProject(phaseContext, accountConfig) {
     let {appName, pipelineName, phaseName} = phaseContext;
-    let pypiProjectName = getPypiProjectName(phaseContext)
+    let pypiProjectName = getPypiProjectName(phaseContext);
+    let buildspecParams = {
+        "pipeline_name": `${appName}.${pipelineName}`,
+        "twine_repo_url": phaseContext.params.server
+    }
     return createPypiPhaseServiceRole(phaseContext.accountConfig, appName)
         .then(pypiPhaseRole => {
             let pypiDeployImage = phaseContext.params.build_image || "aws/codebuild/python:3.5.2";
-            let pypiDeployBuildSpec = util.loadFile(`${__dirname}/pypi-buildspec.yml`);
-
-            return codeBuildCalls.getProject(pypiProjectName)
-                .then(buildProject => {
-                    if (!buildProject) {
-                        winston.info(`Creating PyPi deploy phase CodeBuild project ${pypiProjectName}`);
-                        return codeBuildCalls.createProject(pypiProjectName, appName, pipelineName, phaseName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec);
-                    }
-                    else {
-                        winston.info(`Updating PyPi deploy phase CodeBuild project ${pypiProjectName}`);
-                        return codeBuildCalls.updateProject(pypiProjectName, appName, pipelineName, phaseName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec)
-                    }
+            return util.compileHandlebarsTemplate(`${__dirname}/pypi-buildspec.yml`, buildspecParams)
+                .then(pypiDeployBuildSpec =>{
+                    return codeBuildCalls.getProject(pypiProjectName)
+                        .then(buildProject => {
+                            if (!buildProject) {
+                                winston.info(`Creating PyPi deploy phase CodeBuild project ${pypiProjectName}`);
+                                return codeBuildCalls.createProject(pypiProjectName, appName, pipelineName, phaseName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec);
+                            }
+                            else {
+                                winston.info(`Updating PyPi deploy phase CodeBuild project ${pypiProjectName}`);
+                                return codeBuildCalls.updateProject(pypiProjectName, appName, pipelineName, phaseName, pypiDeployImage, {}, phaseContext.accountConfig.account_id, pypiPhaseRole.Arn, phaseContext.accountConfig.region, pypiDeployBuildSpec)
+                            }
+                        });
                 });
         })
         .then(() => {

--- a/lib/phases/pypi/pypi-buildspec.yml
+++ b/lib/phases/pypi/pypi-buildspec.yml
@@ -2,11 +2,11 @@ version: 0.2
 
 env:
   parameter-store:
-    TWINE_USERNAME: {{pipeline_name}}.twine_username
-    TWINE_PASSWORD: {{pipeline_name}}.twine_password
-    TWINE_REPOSITORY: {{pipeline_name}}.twine_repo
+    TWINE_USERNAME: {{parameter_prefix}}.twine_username
+    TWINE_PASSWORD: {{parameter_prefix}}.twine_password
+    TWINE_REPOSITORY: {{parameter_prefix}}.twine_repo
     {{#if twine_repo_url}}
-    TWINE_REPOSITORY_URL: {{pipeline_name}}.twine_repo
+    TWINE_REPOSITORY_URL: {{parameter_prefix}}.twine_repo
     {{/if}}
 
 phases:

--- a/lib/phases/pypi/pypi-buildspec.yml
+++ b/lib/phases/pypi/pypi-buildspec.yml
@@ -1,15 +1,20 @@
 version: 0.2
 
+env:
+  parameter-store:
+    TWINE_USERNAME: {{pipeline_name}}.twine_username
+    TWINE_PASSWORD: {{pipeline_name}}.twine_password
+    TWINE_REPOSITORY: {{pipeline_name}}.twine_repo
+    {{#if twine_repo_url}}
+    TWINE_REPOSITORY_URL: {{pipeline_name}}.twine_repo
+    {{/if}}
+
 phases:
   pre_build:
     commands:
     - pip install twine wheel awscli
     - pip install -r requirements.txt
     - rm -rf dist
-    - export TWINE_USERNAME=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_username | grep 'Value' | awk '{print $2}' | tr -d '",')
-    - export TWINE_PASSWORD=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_password --with-decryption | grep 'Value' | awk '{print $2}' | tr -d '",')
-    - export TWINE_REPOSITORY=$(aws ssm get-parameters --names ${HANDEL_PIPELINE_NAME}.twine_repo | grep 'Value' | awk '{print $2}' | tr -d '",')
-    - if [ "$TWINE_REPOSITORY" != "pypi" ]; then export TWINE_REPOSITORY_URL=$TWINE_REPOSITORY; fi
   build:
     commands:
     - python setup.py sdist bdist_wheel


### PR DESCRIPTION
This refactor changes the method of getting parameter store parameters in the embedded buildspec.yml files from the awscli+bash wizardry to the builtin methods now available.

Also it adds pipeline name to parameters to avoid conflicts if someone has more than one pipeline in the same account.