### PR TITLE
Tag created Handel stacks with pipeline name

### DIFF
--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  *
  */
-import * as async from 'async';
 import * as AWS from 'aws-sdk';
 import { AccountConfig } from 'handel/src/datatypes/account-config';
 import * as codepipelineCalls from '../aws/codepipeline-calls';
-import { HandelCodePipelineFile, PhaseConfig, PhaseContext, PhaseDeployer, PhaseDeployers, PhaseSecrets } from '../datatypes/index';
+import { HandelCodePipelineFile, PhaseConfig, PhaseContext, PhaseDeployer, PhaseDeployers, PhaseSecrets } from '../datatypes';
 
 interface PipelineCheckErrors {
     [pipelineName: string]: string[];

--- a/src/phases/handel/deploy-buildspec.yml
+++ b/src/phases/handel/deploy-buildspec.yml
@@ -6,4 +6,4 @@ phases:
     - npm install -g handel
   build:
     commands:
-    - handel deploy -e $ENVS_TO_DEPLOY -c $HANDEL_ACCOUNT_CONFIG
+    - handel deploy -e $ENVS_TO_DEPLOY -c $HANDEL_ACCOUNT_CONFIG -t handel-codepipeline-name=$PIPELINE_NAME

--- a/src/phases/handel/index.ts
+++ b/src/phases/handel/index.ts
@@ -21,6 +21,7 @@ import * as codeBuildCalls from '../../aws/codebuild-calls';
 import * as iamCalls from '../../aws/iam-calls';
 import * as util from '../../common/util';
 import { PhaseConfig, PhaseContext, PhaseSecrets } from '../../datatypes/index';
+import {getPipelineProjectName} from "../../aws/codepipeline-calls";
 
 export interface HandelConfig extends PhaseConfig {
     environments_to_deploy: string[];
@@ -55,7 +56,8 @@ async function createDeployPhaseCodeBuildProject(phaseContext: PhaseContext<Hand
 
     const handelDeployEnvVars = {
         ENVS_TO_DEPLOY: phaseContext.params.environments_to_deploy.join(','),
-        HANDEL_ACCOUNT_CONFIG: new Buffer(JSON.stringify(accountConfig)).toString('base64')
+        HANDEL_ACCOUNT_CONFIG: new Buffer(JSON.stringify(accountConfig)).toString('base64'),
+        PIPELINE_NAME: getPipelineProjectName(appName, pipelineName)
     };
     const handelDeployImage = 'aws/codebuild/nodejs:7.0.0';
     const buildSpecPath = `${__dirname}/deploy-buildspec.yml`;

--- a/test/common/handel-test.js
+++ b/test/common/handel-test.js
@@ -196,7 +196,7 @@ describe('handel interface', function () {
                     expect(result).to.have.property('policies').which.deep.includes(
                         s3BucketStatement, s3ObjectStatement
                     );
-                    expect(result).to.have.property('environmentVariables').which.deep.equals({
+                    expect(result).to.have.property('environmentVariables').which.includes({
                         "BUCKET_BUCKET_NAME": 'test',
                         "BUCKET_BUCKET_URL": 'https://test.s3.amazonaws.com/',
                         "BUCKET_REGION_ENDPOINT": 's3-us-west-2.amazonaws.com'


### PR DESCRIPTION
This is from
https://github.com/byu-oit/handel/issues/332#issuecomment-360587503.
Sets the 'handel-codepipeline-name' tag on all stacks created by the
 `handel` phase with the name of the pipeline.

This depends on https://github.com/byu-oit/handel/pull/368 being merged.

It will take either a manual edit or a redeploy of any existing pipelines
for this change to take effect.

Future work: tag all shared resources (like the artifact bucket) with
tags from the account config file.