### PR TITLE
fix for issue126: fixed issue with phase name, deleting old pipelines

### DIFF
--- a/src/aws/codepipeline-calls.ts
+++ b/src/aws/codepipeline-calls.ts
@@ -263,6 +263,17 @@ export async function deregisterWebhook(webhookName: string): Promise<AWS.CodePi
     return await awsWrapper.codePipeline.deregisterWebhook(webhook);
 }
 
+export async function webhookExists(webhookName: string): Promise<boolean> {
+    const listWebhooksResult = await awsWrapper.codePipeline.listWebhooks();
+    const webhooks = listWebhooksResult.webhooks;
+    for(const webhook of webhooks as any) {
+        if(webhook.definition.name === webhookName) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export async function listWebhooks(): Promise<AWS.CodePipeline.ListWebhooksOutput> {
     return await awsWrapper.codePipeline.listWebhooks();
 }

--- a/src/aws/codepipeline-calls.ts
+++ b/src/aws/codepipeline-calls.ts
@@ -266,7 +266,10 @@ export async function deregisterWebhook(webhookName: string): Promise<AWS.CodePi
 export async function webhookExists(webhookName: string): Promise<boolean> {
     const listWebhooksResult = await awsWrapper.codePipeline.listWebhooks();
     const webhooks = listWebhooksResult.webhooks;
-    for(const webhook of webhooks as any) {
+    if(!webhooks) {
+        return false;
+    }
+    for(const webhook of webhooks) {
         if(webhook.definition.name === webhookName) {
             return true;
         }

--- a/src/phases/github/index.ts
+++ b/src/phases/github/index.ts
@@ -110,6 +110,7 @@ export function deletePhase(phaseContext: PhaseContext<GithubConfig>, accountCon
 export async function addWebhook(phaseContext: PhaseContext<GithubConfig>) {
     const appName = phaseContext.appName;
     const pipelineName = phaseContext.pipelineName;
+    const phaseName = phaseContext.phaseName;
     const pipelineProjectName = codepipelineCalls.getPipelineProjectName(appName, pipelineName);
     const webhookName = codepipelineCalls.getPipelineWebhookName(appName, pipelineName);
     const webhookExists = await checkWebhookExists(webhookName);
@@ -118,7 +119,7 @@ export async function addWebhook(phaseContext: PhaseContext<GithubConfig>) {
             'webhook': {
                 'name': webhookName,
                 'targetPipeline': pipelineProjectName,
-                'targetAction': 'GitHub',
+                'targetAction': phaseName,
                 'filters': [
                     {
                         'jsonPath': '$.ref',

--- a/src/phases/github/index.ts
+++ b/src/phases/github/index.ts
@@ -141,8 +141,11 @@ export async function removeWebhook(phaseContext: PhaseContext<GithubConfig>) {
     const appName = phaseContext.appName;
     const pipelineName = phaseContext.pipelineName;
     const webhookName = codepipelineCalls.getPipelineWebhookName(appName, pipelineName);
-    const deregisterResult = await codepipelineCalls.deregisterWebhook(webhookName);
-    const deleteWebhook = await codepipelineCalls.deleteWebhook(webhookName);
+    const webhookExists = await codepipelineCalls.webhookExists(webhookName);
+    if(webhookExists) {
+        const deregisterResult = await codepipelineCalls.deregisterWebhook(webhookName);
+        const deleteWebhook = await codepipelineCalls.deleteWebhook(webhookName);
+    }
 }
 
 async function checkWebhookExists(webhookName: string): Promise<boolean> {

--- a/test/aws/codepipeline-calls-test.ts
+++ b/test/aws/codepipeline-calls-test.ts
@@ -164,14 +164,41 @@ describe('codepipelineCalls module', () => {
         });
     });
 
-        describe('listWebhooks', () => {
-            it('should list the webhooks', async () => {
-                const listWebhookStub = sandbox.stub(awsWrapper.codePipeline, 'listWebhooks').resolves({
-                    webhooks: []
-                });
-
-                const webhooks = await codepipelineCalls.listWebhooks();
-                expect(listWebhookStub.callCount).to.equal(1);
+    describe('listWebhooks', () => {
+        it('should list the webhooks', async () => {
+            const listWebhookStub = sandbox.stub(awsWrapper.codePipeline, 'listWebhooks').resolves({
+                webhooks: []
             });
+
+            const webhooks = await codepipelineCalls.listWebhooks();
+            expect(listWebhookStub.callCount).to.equal(1);
+        });
+    });
+
+    describe('webhookExists', () => {
+        it('should return true if webhook exists', async () => {
+            const listWebhookStub = sandbox.stub(awsWrapper.codePipeline, 'listWebhooks').resolves({
+                webhooks: [
+                    {
+                        definition: {
+                            name: 'name-of-webhook'
+                        }
+                    }
+                ]
+            });
+
+            const webhookExists = await codepipelineCalls.webhookExists('name-of-webhook');
+            expect(listWebhookStub.callCount).to.equal(1);
+            expect(webhookExists).to.equal(true);
+        });
+        it('should return false if webhook doesn\'t exist', async () => {
+            const listWebhookStub = sandbox.stub(awsWrapper.codePipeline, 'listWebhooks').resolves({
+                webhooks: []
+            });
+
+            const webhookExists = await codepipelineCalls.webhookExists('name-of-webhook');
+            expect(listWebhookStub.callCount).to.equal(1);
+            expect(webhookExists).to.equal(false);
+        });
     });
 });

--- a/test/phases/github/github-test.ts
+++ b/test/phases/github/github-test.ts
@@ -144,12 +144,23 @@ describe('github phase module', () => {
     });
 
     describe('removeWebhook', () => {
-        it('should deregister webhook and delete it', async () => {
+        it('if webhook exists, should deregister webhook and delete it', async () => {
+            const webhookExistsStub = sandbox.stub(codepipelineCalls, 'webhookExists').returns(Promise.resolve(true));
             const deleteWebhookStub = sandbox.stub(codepipelineCalls, 'deleteWebhook');
             const deregisterWebhookStub = sandbox.stub(codepipelineCalls, 'deregisterWebhook');
             await github.removeWebhook(phaseContext);
+            expect(webhookExistsStub.callCount).to.equal(1);
             expect(deleteWebhookStub.callCount).to.equal(1);
             expect(deregisterWebhookStub.callCount).to.equal(1);
+        });
+        it('if webhook doesn\'t exist, should not try to deregister or delete webhook', async () => {
+            const webhookExistsStub = sandbox.stub(codepipelineCalls, 'webhookExists').returns(Promise.resolve(false));
+            const deleteWebhookStub = sandbox.stub(codepipelineCalls, 'deleteWebhook');
+            const deregisterWebhookStub = sandbox.stub(codepipelineCalls, 'deregisterWebhook');
+            await github.removeWebhook(phaseContext);
+            expect(webhookExistsStub.callCount).to.equal(1);
+            expect(deleteWebhookStub.callCount).to.equal(0);
+            expect(deregisterWebhookStub.callCount).to.equal(0);
         });
     });
 });


### PR DESCRIPTION
The `targetAction` must be the name of the phase, not the type. The name could be anything, and if the name is, for example, `Source`, it causes the deploy or delete to fail. Also, we need to check that a webhook exists before trying to delete it.