### PR TITLE
CodeBuild flag to set "privileged" mode

### DIFF
--- a/docs/phase-types/codebuild.rst
+++ b/docs/phase-types/codebuild.rst
@@ -32,6 +32,11 @@ Parameters
      - Yes
      - 
      - The name of the CodeBuild image to use when building your code. See the `CodeBuild documentation <http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html>`_ for a list of images.
+   * - privileged
+     - boolean
+     - No
+     - false
+     - Set "privileged" mode, which allows you to run Docker inside your image if needed.
    * - environment_variables
      - map
      - No

--- a/src/aws/codebuild-calls.ts
+++ b/src/aws/codebuild-calls.ts
@@ -65,6 +65,7 @@ export interface ProjectInput {
     pipelineName: string;
     phaseName: string;
     imageName: string;
+    privileged?: boolean;
     environmentVariables: any;
     accountId: string;
     serviceRoleArn: string;
@@ -74,7 +75,7 @@ export interface ProjectInput {
 }
 
 function getProjectParams(parameters: ProjectInput): AWS.CodeBuild.CreateProjectInput {
-    const { projectName, appName, pipelineName, phaseName, imageName, environmentVariables, accountId, serviceRoleArn, region, cacheSpec, buildSpec } = parameters;
+    const { projectName, appName, pipelineName, phaseName, imageName, privileged, environmentVariables, accountId, serviceRoleArn, region, cacheSpec, buildSpec } = parameters;
 
     const projectParams: AWS.CodeBuild.Types.CreateProjectInput = {
         name: projectName,
@@ -109,7 +110,7 @@ function getProjectParams(parameters: ProjectInput): AWS.CodeBuild.CreateProject
 
     // If using a custom image, set the build to use privilegedMode. Allows access to docker daemon for docker build
     // http://docs.aws.amazon.com/codebuild/latest/APIReference/API_ProjectEnvironment.html
-    if (imageName.startsWith(accountId)) {
+    if (privileged || imageName.startsWith(accountId)) {
         projectParams.environment.privilegedMode = true;
     }
 

--- a/src/phases/codebuild/index.ts
+++ b/src/phases/codebuild/index.ts
@@ -27,6 +27,7 @@ import { EnvironmentVariables, PhaseConfig, PhaseContext, PhaseSecretQuestion, P
 
 export interface CodeBuildConfig extends PhaseConfig {
     build_image: string;
+    privileged?: boolean;
     environment_variables?: EnvironmentVariables;
     build_role?: string;
     extra_resources?: HandelExtraResources;
@@ -129,6 +130,7 @@ async function createBuildPhaseCodeBuildProject(phaseContext: PhaseContext<CodeB
             pipelineName: pipelineName,
             phaseName: phaseName,
             imageName: buildImage,
+            privileged: phaseContext.params.privileged,
             environmentVariables: envVars,
             accountId: phaseContext.accountConfig.account_id.toString(),
             serviceRoleArn: buildPhaseRole.Arn,
@@ -144,6 +146,7 @@ async function createBuildPhaseCodeBuildProject(phaseContext: PhaseContext<CodeB
             pipelineName: pipelineName,
             phaseName: phaseName,
             imageName: buildImage,
+            privileged: phaseContext.params.privileged,
             environmentVariables: envVars,
             accountId: phaseContext.accountConfig.account_id.toString(),
             serviceRoleArn: buildPhaseRole.Arn,

--- a/test/aws/codebuild-calls-test.ts
+++ b/test/aws/codebuild-calls-test.ts
@@ -56,6 +56,44 @@ describe('codebuild calls module', () => {
             expect(createProjectStub.callCount).to.equal(1);
             expect(project!.name).to.equal(projectName);
         });
+        it('should set privileged mode as specified', async () => {
+            const projectName = 'FakeProject';
+
+            const createProjectStub = sandbox.stub(awsWrapper.codeBuild, 'createProject').callsFake(
+                projectParams => Promise.resolve({
+                    project: {
+                        name: projectName,
+                        environment: {
+                            privilegedMode: projectParams!.environment!.privilegedMode
+                        }
+                    }
+                })
+            );
+
+            const params: codeBuildCalls.ProjectInput = {
+                projectName: projectName,
+                appName: projectName,
+                pipelineName: 'pipeline',
+                phaseName: 'phase',
+                imageName: 'FakeImage',
+                environmentVariables: {},
+                accountId: '777777777777',
+                serviceRoleArn: 'FakeArn',
+                region: 'us-west-2'
+            };
+
+            let project = await codeBuildCalls.createProject(params);
+            expect(project!.environment!.privilegedMode).to.equal(undefined);
+
+            params.privileged = true;
+            project = await codeBuildCalls.createProject(params);
+            expect(project!.environment!.privilegedMode).to.equal(true);
+
+            params.privileged = undefined;
+            params.imageName = params.accountId + '/FakeImage';
+            project = await codeBuildCalls.createProject(params);
+            expect(project!.environment!.privilegedMode).to.equal(true);
+        });
     });
 
     describe('updateProject', () => {


### PR DESCRIPTION
Need a manual "privileged" mode flag, so we can create docker images inside AWS-provided build images. Current code only sets "privileged" mode if a custom build image is used.