### PR TITLE
update HandelDeploy build image

### DIFF
--- a/src/phases/handel/deploy-buildspec.yml
+++ b/src/phases/handel/deploy-buildspec.yml
@@ -1,6 +1,9 @@
-version: 0.1
+version: 0.2
 
 phases:
+  install:
+    runtime-versions:
+      nodejs: 10
   pre_build:
     commands:
     - npm install -g handel

--- a/src/phases/handel/index.ts
+++ b/src/phases/handel/index.ts
@@ -56,7 +56,7 @@ async function createDeployPhaseCodeBuildProject(phaseContext: PhaseContext<Hand
         HANDEL_ACCOUNT_CONFIG: new Buffer(JSON.stringify(accountConfig)).toString('base64'),
         PIPELINE_NAME: getPipelineProjectName(appName, pipelineName)
     };
-    const handelDeployImage = 'aws/codebuild/nodejs:7.0.0';
+    const handelDeployImage = 'aws/codebuild/standard:2.0';
     const buildSpecPath = `${__dirname}/deploy-buildspec.yml`;
     const handelDeployBuildSpec = util.loadFile(buildSpecPath);
     if(!handelDeployBuildSpec) {


### PR DESCRIPTION
This updates the handelDeploy build image to aws/codebuild/standard:2.0 and updates the buildspec.yml